### PR TITLE
修复peerDependencies遗漏prop-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   },
   "peerDependencies": {
     "react": ">=16.0.0",
-    "react-dom": ">=16.0.0"
+    "react-dom": ">=16.0.0",
+    "prop-types": "^15.6.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",


### PR DESCRIPTION
webpack配置的external中有prop-types，但是peerDependencies中缺没有