### PR TITLE
feat: better tree shaking support.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,6 @@
       "presets": ["react-app"]
     },
     "production": {
-      "plugins": ["transform-react-remove-prop-types"],
       "presets": ["react-app"]
     },
     "publish": {
@@ -15,7 +14,8 @@
           {
             "useBuiltIns": true
           }
-        ]
+        ],
+        "@babel/plugin-transform-runtime"
       ],
       "presets": [
         ["@babel/preset-env",
@@ -27,7 +27,8 @@
               ]
             },
             "loose": true,
-            "useBuiltIns": "entry"
+            "useBuiltIns": "entry",
+            "modules": false
           }
         ],
         "@babel/preset-react"

--- a/package.json
+++ b/package.json
@@ -43,12 +43,14 @@
     "build-css": "node scripts/build-css.js",
     "build": "npm-run-all build-*"
   },
+  "sideEffects": false,
   "peerDependencies": {
     "prop-types": "^15.6.0",
     "react": ">=16.0.0",
     "react-dom": ">=16.0.0"
   },
   "dependencies": {
+    "@babel/runtime": "^7.1.5",
     "classnames": "^2.2.5",
     "create-react-context": "^0.2.3",
     "date-fns": "2.0.0-alpha.10",
@@ -60,6 +62,7 @@
     "@babel/core": "^7.1.6",
     "@babel/plugin-proposal-class-properties": "^7.1.0",
     "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+    "@babel/plugin-transform-runtime": "^7.1.0",
     "@babel/polyfill": "^7.0.0",
     "@babel/preset-env": "^7.1.6",
     "@babel/preset-react": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -822,6 +822,16 @@
     resolve "^1.8.1"
     semver "^5.5.1"
 
+"@babel/plugin-transform-runtime@^7.1.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.2.0.tgz#566bc43f7d0aedc880eaddbd29168d0f248966ea"
+  integrity sha512-jIgkljDdq4RYDnJyQsiWbdvGeei/0MOTtSHKO/rfbd/mXBxNpdlulMx49L0HQ4pug1fXannxoqCI+fYSle9eSw==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    resolve "^1.8.1"
+    semver "^5.5.1"
+
 "@babel/plugin-transform-shorthand-properties@^7.0.0":
   version "7.0.0"
   resolved "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0.tgz#85f8af592dcc07647541a0350e8c95c7bf419d15"
@@ -1021,6 +1031,13 @@
   version "7.1.5"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.1.5.tgz#4170907641cf1f61508f563ece3725150cc6fe39"
   integrity sha512-xKnPpXG/pvK1B90JkwwxSGii90rQGKtzcMt2gI5G6+M0REXaq6rOHsGC2ay6/d0Uje7zzvSzjEzfR3ENhFlrfA==
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
+"@babel/runtime@^7.1.5":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.2.0.tgz#b03e42eeddf5898e00646e4c840fa07ba8dcad7f"
+  integrity sha512-oouEibCbHMVdZSDlJBO6bZmID/zA/G/Qx3H1d3rSNPTD+L8UNKvCat7aKWSJ74zYbm5zWGh0GQN0hKj8zYFTCg==
   dependencies:
     regenerator-runtime "^0.12.0"
 


### PR DESCRIPTION
1. 添加sideEffects标示，便于webpack的tree shaking；
2. 使用`@babel/plugin-transform-runtime`插件，减少shineout的体积(lib)；
