### PR TITLE
change initial time when set defaultTime and fix min bug

### DIFF
--- a/src/DatePicker/Picker.js
+++ b/src/DatePicker/Picker.js
@@ -24,7 +24,9 @@ class Picker extends PureComponent {
     }
 
     this.state = { mode }
-    this.defaultCurrent = utils.newDate()
+    this.defaultCurrent = new Date(
+      utils.formatDateWithDefaultTime(utils.newDate(), undefined, props.defaultTime[0], 'yyyy-MM-dd HH:mm:ss')
+    )
     this.handleModeChange = this.handleModeChange.bind(this)
     this.handleEnter = this.handleMouse.bind(this, true)
     this.handleLeave = this.handleMouse.bind(this, false)
@@ -93,6 +95,7 @@ Picker.propTypes = {
   index: PropTypes.number,
   children: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   handleHover: PropTypes.func,
+  defaultTime: PropTypes.array,
 }
 
 export default Picker

--- a/src/DatePicker/Time.js
+++ b/src/DatePicker/Time.js
@@ -52,7 +52,9 @@ class Time extends PureComponent {
 
     if (pos !== 'start') {
       if (!isDisabled && min) {
-        if (date.getHours() !== min.getHours() && utils.compareAsc(date, min) < 0) return
+        // if (date.getHours() !== min.getHours() && utils.compareAsc(date, min) < 0) return
+        // fix 'min' props invalid bug when hours are equal. To be confirmed...
+        if (utils.compareAsc(date, min) < 0) return
         if (range && utils.compareAsc(date, utils.addSeconds(min, range)) > 0) return
       }
       if (!isDisabled && max) {


### PR DESCRIPTION
modify: change initial time when set defaultTime
fix: fix 'min' props invalid bug when hours are equal