### PR TITLE
fix: EditableArea context zIndex error

### DIFF
--- a/src/styles/editableArea.less
+++ b/src/styles/editableArea.less
@@ -96,6 +96,7 @@
 
     &-absolute {
         transform: translateY(-@height);
+        z-index: 2; // fix EditableArea context zIndex error
     }
 
     &-focus {


### PR DESCRIPTION
🐞 fix:`EditableArea` component context zIndex when absolute is true