### PR TITLE
fix: EditableArea cont autosize when absolute is true

### DIFF
--- a/src/styles/editableArea.less
+++ b/src/styles/editableArea.less
@@ -23,6 +23,7 @@
       font-family: @font-family-base;
       word-wrap: break-word;
       word-break: break-all;
+      white-space: pre-wrap;  // fix: EditableArea cont autosize when absolute is true
       position: absolute;
       top: 0;
       left: 0;


### PR DESCRIPTION
🐞 fix:`EditableArea` component cant autosize when absolute is true