### PR TITLE
fix: table columns expand align center

### DIFF
--- a/src/styles/table.less
+++ b/src/styles/table.less
@@ -517,6 +517,14 @@
       justify-content: center;
     }
   }
+
+  td&-align-center{
+    .@{table-prefix}-icon-expand-plus, .@{table-prefix}-icon-expand-sub {
+      display: inline-block;
+      margin-top: 4px;
+      margin-bottom: 0;
+    }
+  }
   
   td&-align-right, th&-align-right {
     text-align: right;


### PR DESCRIPTION
fix: table columns icon center when type is expand