### PR TITLE
fix: select scroll appears blank under the zoom

### DIFF
--- a/src/styles/select.less
+++ b/src/styles/select.less
@@ -335,7 +335,7 @@
     padding: @dropdown-item-padding-y @dropdown-padding-x+12 @dropdown-item-padding-y @dropdown-padding-x;
     color: @select-option-color;
     font-size: @font-size-base;
-    line-height: 20px;
+    line-height: 22px;
     text-overflow: ellipsis;
     transition: none;
     white-space: nowrap;


### PR DESCRIPTION
fix: select scroll appears blank under the zoom