### PR TITLE
fixed heading anchor-id error in doc of 'Rule'

### DIFF
--- a/site/Components/MarkDown/MarkDown.js
+++ b/site/Components/MarkDown/MarkDown.js
@@ -15,7 +15,7 @@ const exampleReg = /^<example name="([\w|-]+)"/
 
 const createId = (level, str) => {
   if (level === 4) return getUidStr()
-  return `${level}-${(str || '').replace(/[\W|-]/g, '-')}`
+  return `${level}-${(str || '').replace(/\s/g, '-')}`
 }
 
 export default function MarkDown({ onHeadingSetted, codes, examples, source }) {

--- a/site/Components/Navable/index.js
+++ b/site/Components/Navable/index.js
@@ -14,7 +14,7 @@ const scrollTo = id => {
   }
 }
 
-export default function(Component) {
+export default function (Component) {
   return function Nav(prop) {
     const [active, setActive] = useState('')
     const [headings] = useState([])
@@ -29,7 +29,7 @@ export default function(Component) {
     const hashScroll = useCallback(
       () => {
         if (hash) {
-          const element = document.querySelector(hash)
+          const element = document.querySelector(decodeURI(hash))
           if (element)
             setTimeout(() => {
               element.scrollIntoView()


### PR DESCRIPTION
Rule组件文档中锚点链接不正确，原因是Markdown的中文标题生成id不正确（中文字符被替换成了-）