### PR TITLE
fix: collapse all tree table make empty data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shineout",
-  "version": "1.6.3-rc.25",
+  "version": "1.6.3-rc.26",
   "description": "Shein 前端组件库",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/site/pages/documentation/changelog-rc/1.x.x.md
+++ b/site/pages/documentation/changelog-rc/1.x.x.md
@@ -1,5 +1,10 @@
 # 更新日志
 
+### 1.6.3-rc.26
+ - 修复 Table 树形数据“折叠全部”导致数据滚动条异常的问题
+ - 新增 List/Breadcrumb/Radio/Transfer 组件的 TS 声明（@hyperMoss，@dixdiydiz）
+ - 优化文档
+ 
 ### 1.6.3-rc.25
  - 修复 Input.Number onBlur 丢失校验信息
  - 优化 Table 虚拟列表滚动

--- a/src/Table/SeperateTable.js
+++ b/src/Table/SeperateTable.js
@@ -37,6 +37,7 @@ class SeperateTable extends PureComponent {
     this.handleColgroup = this.handleColgroup.bind(this)
     this.handleScroll = this.handleScroll.bind(this)
     this.handleSortChange = this.handleSortChange.bind(this)
+    this.scrollToTop = this.scrollToTop.bind(this)
 
     this.cachedRowHeight = []
     this.lastScrollArgs = {}
@@ -284,6 +285,10 @@ class SeperateTable extends PureComponent {
     this[key] = el
   }
 
+  scrollToTop() {
+    this.scrollToIndex(0)
+  }
+
   scrollToIndex(index, callback) {
     if (!this.$isMounted) return
     if (index >= 1) index -= 1
@@ -485,6 +490,7 @@ class SeperateTable extends PureComponent {
               dataUpdated={dataUpdated}
               resize={resize}
               colgroup={colgroup}
+              onScrollTop={this.scrollToTop}
             />
           </table>
         </div>

--- a/src/Table/Tbody.js
+++ b/src/Table/Tbody.js
@@ -96,6 +96,8 @@ class Tbody extends PureComponent {
   }
 
   componentDidUpdate(prevProps) {
+    const { onScrollTop, data } = this.props
+    if (onScrollTop && prevProps.data.length && data.length === 0) onScrollTop()
     if (this.props.resize || !this.colgroupSetted || !compareColumns(prevProps.columns, this.props.columns)) {
       setTimeout(() => {
         this.bodyRender()


### PR DESCRIPTION
问题描述：
在虚拟列表的Tree Table下，滚动超过 rowsInView 的时候，将 treeExpandKeys 置空，会出现空白的问题。

问题原因：
在 treeExpandKeys 置空的时候，虚拟列表 currentIndex 没有改变，导致产生的数据长度错误（可能为空）。

问题解决：
在 Tbody 中，如果数据长度由正常变为空，则调用 scrollToIndex 至 0，这个操作能重置 currentIndex。