### PR TITLE
fix: popover hover dismiss on firefix

### DIFF
--- a/src/styles/popover.less
+++ b/src/styles/popover.less
@@ -2,6 +2,7 @@
 @import './themes/@{so-theme}.less';
 
 @popover-prefix: ~'@{so-prefix}-popover';
+@popover-arrow-size: 12px;
 
 .@{popover-prefix} {
   @keyframe-opacity: ~'@{popover-prefix}-kf-opacity';
@@ -66,8 +67,8 @@
     &:after {
       left: 0;
       right: 0;
-      bottom: -@popover-arrow-margin;
-      height: @popover-arrow-margin;
+      bottom: -@popover-arrow-size;
+      height: @popover-arrow-size;
     }
 
     .@{popover-prefix}-arrow {
@@ -103,8 +104,8 @@
     &:after {
       top: 0;
       bottom: 0;
-      right: -@popover-arrow-margin;
-      width: @popover-arrow-margin;
+      right: -@popover-arrow-size;
+      width: @popover-arrow-size;
     }
 
     .@{popover-prefix}-arrow {
@@ -140,8 +141,8 @@
     &:after {
       top: 0;
       bottom: 0;
-      left: -@popover-arrow-margin;
-      width: @popover-arrow-margin;
+      left: -@popover-arrow-size;
+      width: @popover-arrow-size;
     }
 
     .@{popover-prefix}-arrow {
@@ -178,8 +179,8 @@
     &:after {
       left: 0;
       right: 0;
-      top: -@popover-arrow-margin;
-      height: @popover-arrow-margin;
+      top: -@popover-arrow-size;
+      height: @popover-arrow-size;
     }
 
     .@{popover-prefix}-arrow {


### PR DESCRIPTION
问题描述：firefox中，popover使用hover打开下，将鼠标缓慢移动至目标元素和弹出元素中间的空白区域会导致popover消失。
问题原因：之前中间空白区域采用了伪元素进行元素自身区域的扩展，不过10px并不能覆盖完全，在chrome上表现正常，但是firefox中未能成功覆盖。
问题解决：将原有的10px宽度扩展至12px，以此来解决firefox的兼容性问题。