### PR TITLE
feat: table add rowClickAttr with true

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shineout",
-  "version": "1.6.3-rc.27",
+  "version": "1.6.3-rc.28",
   "description": "Shein 前端组件库",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/site/pages/components/Table/cn.md
+++ b/site/pages/components/Table/cn.md
@@ -30,7 +30,7 @@
 | value | any[] | 无 | 当前选中值，格式和 onRowSelect 返回值一致 |
 | empty | string \| ReactNode | 无数据 | 空数据文案 |
 | verticalAlign | 'top' \| 'middle' | 'top' | 单元格内容垂直对齐方式 |
-| rowClickAttr | string \| string[] | \['*'\] | 设置行内元素的attribut来按需触发onRowClick, '*'表示接受行点击触发 |
+| rowClickAttr | true \| string \| string[] | \['*'\] | 设置行内元素的attribut来按需触发onRowClick, '*'表示接受行点击触发 |
 | sorter | (sortKey: any, sorter: 'asc' \| 'desc', sortedList: object[]) => (a: object, b: object) => boolean | alphaSort(Column.sorter, sorter) | 表格统一排序函数，参数分别为 Column.sorter 和 排序方式;<br />支持多列排序，sorter传入对象{ rule: string \| function, weight: number }, rule为排序规则，为字符串时参考单列排序的用法, weight为权重，指明排序的优先级. <br />多列排序时，sortedList返回所有参与排序的字段信息|
 | treeExpandKeys | any[] | 无  | 树形数据展开行，受控 |
 | hover | boolean | true | 数据行鼠标悬浮高亮效果 |

--- a/site/pages/components/Table/en.md
+++ b/site/pages/components/Table/en.md
@@ -30,7 +30,7 @@
 | value | any[] | none | The current selected value. |
 | empty | string \| ReactNode | Data not found | empty text |
 | verticalAlign | 'top' \| 'middle' | 'top' | vertical align with content |
-| rowClickAttr | string \| string[] | \['*'\] | Sets the attribute of inner element to trigger onRowClick as needed, and '*' to accept the row click |
+| rowClickAttr | true \| string \| string[] | \['*'\] | Sets the attribute of inner element to trigger onRowClick as needed, and '*' to accept the row click |
 | sorter | (sortKey: any, sorter: 'asc' \| 'desc', sortedList: any[]) => (a: object, b: object) => boolean | alphaSort(Column.sorter, sorter) | the method of table sort，args are Column.sorter and order<br /> Multi-column sorting is supported. The sorter passes in the object {rule: string \| function, weight: number}, where rule is a sorting rule, which refers to the use of single-column sorting when it is a string, weight is the weight, indicating the priority of the order<br /> When sorting on multiple columns, sortedList returns information about all fields involved in sorting|
 | treeExpandKeys | any[] | none  | Tree Table expanded row keys |
 | onTreeExpand | (openKeys: string[], data: object, expand: boolean) => void | none | expand row change, keys is expanded row keys |

--- a/site/pages/components/Table/example-25-row-click-attr.js
+++ b/site/pages/components/Table/example-25-row-click-attr.js
@@ -36,19 +36,22 @@ export default class extends React.PureComponent {
     count: 0,
     attrs: ['*'],
   }
+
   handleClick = () => {
     this.setState(prevState => ({ count: prevState.count + 1 }))
   }
+
   handleChange = value => {
     this.setState({
       attrs: value,
     })
   }
+
   render() {
     const { attrs, count } = this.state
     return (
       <div>
-        <Table rowClickAttr={attrs} onRowClick={this.handleClick} keygen="id" columns={columns} data={dataList} />
+        <Table rowClickAttr onRowClick={this.handleClick} keygen="id" columns={columns} data={dataList} />
         Select rowClickAttr：
         <Select
           style={{ width: '300px', margin: '0 0 10px 10px' }}
@@ -60,7 +63,7 @@ export default class extends React.PureComponent {
           onChange={this.handleChange}
         />
         <div>
-          onRowClick call count： <strong>{count}</strong>
+          <span>onRowClick call count： </span> <strong>{count}</strong>
         </div>
       </div>
     )

--- a/site/pages/documentation/changelog-rc/1.x.x.md
+++ b/site/pages/documentation/changelog-rc/1.x.x.md
@@ -1,5 +1,11 @@
 # 更新日志
 
+### 1.6.3-rc.28
+ - Cascader 支持逐个删除
+ - Table rowClickAttr 支持点击任意元素触发行点击事件
+ - Input/Textarea/Slider 新增TS声明（@Dod_Annie）
+ - 优化文档
+
 ### 1.6.3-rc.27
  - Cascader 多选支持搜索
  - Cascader 支持 size 属性

--- a/src/Table/Tr.js
+++ b/src/Table/Tr.js
@@ -95,6 +95,8 @@ class Tr extends Component {
   }
 
   isFireElement(el) {
+    const { rowClickAttr } = this.props
+    if (rowClickAttr === true) return true
     return this.getRowClickAttr().find(v => el.hasAttribute(v))
   }
 
@@ -245,7 +247,7 @@ Tr.propTypes = {
   rowData: PropTypes.object,
   striped: PropTypes.bool,
   setRowHeight: PropTypes.func,
-  rowClickAttr: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
+  rowClickAttr: PropTypes.oneOfType([PropTypes.bool, PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
   dataUpdated: PropTypes.bool,
   treeExpandKeys: PropTypes.object,
   columnResizable: PropTypes.bool,


### PR DESCRIPTION
- 需求描述：TR中的链接、按钮（任意元素）点击后都想要触发onRowClick，希望`rowClickAttr`支持 在只修改Table属性的情况下来实现这个功能（避免修改太多的代码）
- 解决方案：rowClickAttr除了字符串或字符串数组之外，额外支持设置为`true`来开启这个功能
- 不足：当初在设计 `rowClickAttr` 的时候未考虑完全，将["*"]设为默认值。应该把 * 保留，用于所有元素点击均触发行点击事件的😿（比较好理解，*通配所有）