### PR TITLE
fix: table big data scroll error

### DIFF
--- a/src/Table/SeperateTable.js
+++ b/src/Table/SeperateTable.js
@@ -54,9 +54,10 @@ class SeperateTable extends PureComponent {
   // reset scrollTop when data changed
   componentDidUpdate(prevProps) {
     if (!this.tbody) return
+    const dataChange = this.props.rawData !== prevProps.rawData
     // Use raw data comparison, avoid tree data,
     // because tree data will be re-parsed and generate new data
-    if (this.props.rawData !== prevProps.rawData) {
+    if (dataChange) {
       const resize = prevProps.data.length === 0 && this.props.data.length
       if (resize || this.props.dataChangeResize) this.setState({ resize: true, colgroup: undefined })
       this.resetHeight()
@@ -66,6 +67,7 @@ class SeperateTable extends PureComponent {
       this.resetWidth()
       this.setState({ colgroup: undefined })
     }
+    this.ajustBottom(dataChange)
   }
 
   getIndex(scrollTop = this.state.scrollTop) {
@@ -168,6 +170,16 @@ class SeperateTable extends PureComponent {
       return index
     }
     return max
+  }
+
+  ajustBottom(dataChange) {
+    const reachBottom = this.lastScrollArgs[1] === 1
+    const drag = this.lastScrollArgs[7] === undefined
+    if (!dataChange && reachBottom && drag) {
+      setTimeout(() => {
+        this.handleScroll(...this.lastScrollArgs)
+      })
+    }
   }
 
   updateScrollLeft() {


### PR DESCRIPTION
- 问题描述：Table虚拟列表（超过rowsInView）情况下，使用鼠标拖拽滚动条快速到最下方，数据的位置有偏移。
- 问题原因：在快速滚动到底部时，contentHeight计算不准确，导致scrollTop不正确。
- 问题解决：使用宏任务重新调用handleScroll（等待contentHeight计算完成）
- 注意点：只需要针对鼠标拖拽滚动条滚动，且是数据没有变化的前提下才需要做这个处理。