### PR TITLE
Fix/select tree node width

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shineout",
-  "version": "1.6.3-rc.30",
+  "version": "1.6.3-rc.31",
   "description": "Shein 前端组件库",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/site/pages/documentation/changelog-rc/1.x.x.md
+++ b/site/pages/documentation/changelog-rc/1.x.x.md
@@ -1,5 +1,10 @@
 # 更新日志
 
+### 1.6.3-rc.31
+ - 修复 Table 在“大数据量的情况下拖动滚动条到最下方数据不能展示完整”的问题
+ - 优化 Button link disabled 的展示
+ - 修复 Select 树形数据文字过长溢出的问题
+
 ### 1.6.3-rc.30
  - 优化 Cascader compressed 展示
 

--- a/src/Select/OptionTree.js
+++ b/src/Select/OptionTree.js
@@ -29,9 +29,13 @@ class OptionList extends Component {
 
   renderItem(data) {
     const { renderItem, datum } = this.props
+    const content = renderItem(data)
     return (
-      <span className={selectClass('tree-node', datum.check(data) && 'selected', datum.disabled(data) && 'disabled')}>
-        {renderItem(data)}
+      <span
+        title={typeof content === 'string' ? content : undefined}
+        className={selectClass('tree-node', datum.check(data) && 'selected', datum.disabled(data) && 'disabled')}
+      >
+        {content}
       </span>
     )
   }

--- a/src/styles/select.less
+++ b/src/styles/select.less
@@ -4,6 +4,7 @@
 @select-prefix: ~'@{so-prefix}-select';
 @input-prefix: ~'@{so-prefix}-input';
 @list-prefix: ~'@{so-prefix}-list';
+@tree-node-max-width: 300px;
 
 .@{select-prefix} {
   position: relative;
@@ -226,7 +227,6 @@
     min-width: 100%;
     .@{select-prefix}-tree-wrapper {
       padding: 8px 8px 4px 8px;
-
       .@{so-prefix}-tree-node {
         &:last-child > div {
           padding-bottom: 4px;
@@ -241,7 +241,9 @@
           display: block;
           padding: 0 4px;
           border-radius: 2px;
-
+          max-width: @tree-node-max-width;
+          overflow: hidden;
+          text-overflow: ellipsis;
           &:hover {
             background-color: @primary-color-fade-10;
           }


### PR DESCRIPTION
- 问题描述：select treeData 中节点字数过长，导致溢出屏幕
- 解决方案：单个节点最大宽度设置为 300px，超出显示省略号