### PR TITLE
fix: Tooltip  disabled form elem did not trigger onmouseenter and leave

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shineout",
-  "version": "1.6.3-rc.31",
+  "version": "1.6.3-rc.32",
   "description": "Shein 前端组件库",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/site/pages/documentation/changelog-rc/1.x.x.md
+++ b/site/pages/documentation/changelog-rc/1.x.x.md
@@ -1,5 +1,11 @@
 # 更新日志
 
+### 1.6.3-rc.32
+ - 修复 连续 disabled 按钮使用 Tooltip 后弹出行为异常的问题
+ - Checkbox.Group 新增 block={false} 使子元素强制内联
+ - TreeSelect 选项增加最大宽度限制
+ - 优化 TreeSelect/Select compressed 支持
+
 ### 1.6.3-rc.31
  - 修复 Table 在“大数据量的情况下拖动滚动条到最下方数据不能展示完整”的问题
  - 优化 Button link disabled 的展示

--- a/src/Tooltip/Container.js
+++ b/src/Tooltip/Container.js
@@ -104,8 +104,8 @@ export default function(options) {
 
       const props = { key: 'el' }
       if (trigger === 'hover') {
-        props.onMouseEnter = this.handleShow
-        props.onMouseLeave = () => hide()
+        props.onMouseOver = this.handleShow
+        props.onMouseOut = () => hide()
       } else {
         props.onClick = e => {
           if (e) e.stopPropagation()

--- a/test/src/Tooltip/Tooltip.position.spec.js
+++ b/test/src/Tooltip/Tooltip.position.spec.js
@@ -12,7 +12,7 @@ describe('Tooltip[position]', () => {
           <span>test</span>
         </Tooltip>
       )
-      wrapper.find('span').prop('onMouseEnter')()
+      wrapper.find('span').prop('onMouseOver')()
       jest.runAllTimers()
       expect(document.querySelectorAll(`.${SO_PREFIX}-tooltip-${pos}`).length).toBe(1)
     })


### PR DESCRIPTION
需求描述：
- Tooltip disabledChild 条件下，如果子元素Button是禁用状态(如：disabled button)且相邻的兄弟元素也是禁用状态，onMouseEnter和onMouseLeave将会出现异常，使用`onMouseOver`和`onMouseOut`替换，[具体差异可以查看MDN](https://developer.mozilla.org/zh-CN/docs/Web/API/Element/mouseleave_event)，但是这个地方是可以考虑替换。 **注意：Firefox是全系支持的**

![image](https://user-images.githubusercontent.com/20224722/110282324-41b74680-8019-11eb-9e3f-7e5a143c6b79.png)


```javascript
<div>
    <Button disabled style={{ marginRight: 16 }}>
      first
    </Button>

    <Tooltip tip="top." position="top" disabledChild>
      <Button disabled style={{ margin: 8 }}>
        Disabled
      </Button>
    </Tooltip>
  </div>
```