### PR TITLE
fix: Checkbox.Group in blocked Group

### DIFF
--- a/src/Checkbox/Group.js
+++ b/src/Checkbox/Group.js
@@ -65,7 +65,7 @@ class CheckboxGroup extends PureComponent {
   render() {
     const { block, data, datum, keygen, children } = this.props
 
-    const className = classnames(checkinputClass('group', block && 'block'), this.props.className)
+    const className = classnames(checkinputClass('group', ['no-block', 'block'][Number(block)]), this.props.className)
 
     if (data === undefined) {
       return (

--- a/src/styles/checkinput.less
+++ b/src/styles/checkinput.less
@@ -429,6 +429,11 @@
     margin-bottom: @padding-large-vertical;
   }
 
+  &-no-block & {
+    display: inline-block;
+    margin-bottom: 0;
+  }
+
   &:focus {
     outline: none;
     i.@{checkinput-prefix}-indicator{


### PR DESCRIPTION
- 问题描述：Checkbox.Grpup 嵌套使用时，外层的 block 属性会影响里层的Group
- 问题解决：Checkbox.Group 增加 block={false} 来使 label 强制内联