### PR TITLE
fix: spin zindex cover select option and transfer body zindex

### DIFF
--- a/src/Spin/index.d.ts
+++ b/src/Spin/index.d.ts
@@ -1,6 +1,4 @@
-import * as React from 'react';
-type ReactNode = React.ReactNode;
-
+import * as React from 'react'
 
 
 declare class Spin extends React.Component<SpinProps, {}> {
@@ -12,25 +10,41 @@ export interface SpinProps {
 
   /**
    * color
+   * 
    * 颜色
+   * 
    * default: #6c757d
    */
   color?: string;
 
   /**
    * size
+   * 
    * 尺寸
+   * 
    * default: 40
    */
   size?: number | string;
 
   /**
    * type. See the example for optional values.
+   * 
    * 类型，可选值见示例
+   * 
    * default: 'fading-circle'
    */
   name?: string;
 
+
+  /**
+   * loading
+   * 
+   * 是否载入
+   * 
+   * default: false
+   */
+  loading?: boolean;
+
 }
 
-export default Spin;
+export default Spin

--- a/src/styles/spin.less
+++ b/src/styles/spin.less
@@ -19,7 +19,7 @@
     }
     .@{spin-prefix}-content {
       position: relative;
-      z-index: 2;
+      // z-index: 2;
       &:after {
         position: absolute;
         top: 0;

--- a/src/styles/transfer.less
+++ b/src/styles/transfer.less
@@ -28,6 +28,7 @@
       padding: 2px 0;
       overflow: hidden;
       height: 180px;
+      z-index: 1;
 
       .@{transfer-prefix}-body-container {
         box-sizing: border-box;


### PR DESCRIPTION
需求描述：
- `Spin` content 由于`zIndex` 导致 覆盖 `Select options` 问题，解决方案是去掉`zIndex`设定，然后修复`Transfer body` loading 被覆盖。