### PR TITLE
fix: form onremove or onappend dont trigger onchange

### DIFF
--- a/src/Datum/Form.js
+++ b/src/Datum/Form.js
@@ -104,6 +104,8 @@ export default class {
       val.splice(index, 0, value)
       this.publishValue(name, IGNORE_VALIDATE)
       this.publishError(name)
+      // insert value into Form in onAppend will trigger Form onChange
+      this.handleChange()
     } else {
       this.set(name, [value])
     }
@@ -115,6 +117,8 @@ export default class {
     list.splice(index, 1)
     this.publishValue(name, IGNORE_VALIDATE)
     this.publishError(name)
+    // remove value from Form in onRemove will trigger Form onChange
+    this.handleChange()
   }
 
   remove(name) {


### PR DESCRIPTION
需求分析：
- `Form.FieldSet onRemove || onAppend` 方法未触发 `Form onChange`；解决方案，在执行insert或remove时，trigger onchange