### PR TITLE
Fix/treeselect input

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shineout",
-  "version": "1.6.3-rc.34",
+  "version": "1.6.3-rc.35",
   "description": "Shein 前端组件库",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/site/pages/documentation/changelog-rc/1.x.x.md
+++ b/site/pages/documentation/changelog-rc/1.x.x.md
@@ -1,5 +1,8 @@
 # 更新日志
 
+### 1.6.3-rc.35
+ - 修复 TreeSelect 在 Firefox 上单击无法聚焦的问题
+
 ### 1.6.3-rc.34
  - 移除 Datum.Tree 的样式依赖
  - Input.Number 支持粘贴

--- a/site/pages/documentation/changelog-rc/1.x.x.md
+++ b/site/pages/documentation/changelog-rc/1.x.x.md
@@ -2,6 +2,7 @@
 
 ### 1.6.3-rc.35
  - 修复 TreeSelect 在 Firefox 上单击无法聚焦的问题
+ - 修复 Form.FieldSet Loop 模式下删除和新增后未触发 onChange 的问题
 
 ### 1.6.3-rc.34
  - 移除 Datum.Tree 的样式依赖

--- a/src/TreeSelect/Input.js
+++ b/src/TreeSelect/Input.js
@@ -52,7 +52,7 @@ class FilterInput extends Component {
 
     if (isValidElement(value)) {
       return cloneElement(value, {
-        className: treeSelectClass('input', !multiple && 'full'),
+        className: treeSelectClass('input'),
         ref: this.bindElement,
         key: 'input',
         onInput: this.handleInput,

--- a/src/styles/treeSelect.less
+++ b/src/styles/treeSelect.less
@@ -78,7 +78,7 @@
     }
 
     .@{treeSelect-prefix}-input {
-      display: inline-flex;
+      display: block;
       min-width: 12px;
       flex: 1;
       margin-bottom: @padding-base-vertical;
@@ -87,10 +87,6 @@
 
       &:after {
         content: '\feff ';
-      }
-
-      &.@{treeSelect-prefix}-full {
-        display: block;
       }
     }
 


### PR DESCRIPTION
- 问题描述：Firefox上嵌套flex子元素，设置为 white-space: pre; 样式，点击后偶尔会无法聚焦，输入法的选择框也会跳到屏幕边缘。
- 问题解决：white-space:pre；是之前为了解决onFilter 空格 charcode 码不一致的问题（空格被合并），所以来修改 display: inline-flex 为 block 解决这个问题。