### PR TITLE
fix: Dropdown can't dismiss

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shineout",
-  "version": "1.6.3-rc.35",
+  "version": "1.6.3-rc.36",
   "description": "Shein 前端组件库",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/site/pages/documentation/changelog-rc/1.x.x.md
+++ b/site/pages/documentation/changelog-rc/1.x.x.md
@@ -1,5 +1,8 @@
 # 更新日志
 
+### 1.6.3-rc.36
+ - 修复 Dropdown 在 React17 中无法关闭的问题
+
 ### 1.6.3-rc.35
  - 修复 TreeSelect 在 Firefox 上单击无法聚焦的问题
  - 修复 Form.FieldSet Loop 模式下删除和新增后未触发 onChange 的问题

--- a/src/Dropdown/index.js
+++ b/src/Dropdown/index.js
@@ -88,7 +88,7 @@ class Dropdown extends PureComponent {
 
   toggleDocumentEvent(bind) {
     const method = bind ? 'addEventListener' : 'removeEventListener'
-    document[method]('click', this.clickAway)
+    document[method]('click', this.clickAway, true)
   }
 
   clickAway(e) {


### PR DESCRIPTION
- 问题描述：React17中，Dropdown点击后无法关闭
- 问题原因：初步发现，React17后，在onClick中使用document.addEventListener冒泡绑定的点击事件会一并执行（React17前并不会）。这时程序误认为点击了”面板“外的区域，取消了该事件，导致了再也无法关闭的问题。
- 解决方案：将冒泡改为捕获
- React方面原因：原先的事件系统变更，dom节点的onClick绑定到了自身，在其中执行的事件绑定函数最终被冒泡到了。

更多细节还需要查看源码