### PR TITLE
fix: select columns change data not reset offsetTop

### DIFF
--- a/src/AnimationList/LazyList.js
+++ b/src/AnimationList/LazyList.js
@@ -19,16 +19,23 @@ class LazyList extends PureComponent {
 
   componentDidUpdate(prevProps) {
     if (!this.props.stay && prevProps.data.length !== this.props.data.length) {
-      this.setState({
-        currentIndex: 0,
-        scrollTop: 0,
-      })
+      this.resetScrollTop()
     }
   }
 
   getScrollHeight() {
     const { lineHeight, data } = this.props
     return data.length * lineHeight
+  }
+
+  resetScrollTop() {
+    this.setState({
+      currentIndex: 0,
+      scrollTop: 0,
+    })
+    setTranslate(this.optionInner, '0px', `0px`)
+    this.optionInner.style.marginTop = `0px`
+    this.lastScrollTop = 0
   }
 
   handleScroll(x, y, max, bar, v, h, pixelX, pixelY) {


### PR DESCRIPTION
需求分析：
- `Select` 开启 `lazyload` 时，滚动到最底部，这时change data，重新展开 options 会出现空白（scrollTop偏移量错误）；解决方案是在`LazyList`中`didupdate`重置 `currentIdex`时，重置scrollTop。