### PR TITLE
feat: tabs switch tab will scroll to top

### DIFF
--- a/site/chunks/Components/Tabs.js
+++ b/site/chunks/Components/Tabs.js
@@ -151,7 +151,7 @@ const examples = [
   {
     name: '13-sticky',
     title: locate(
-      '头部附着 \n sticky 属性会开启头部附着功能；sticky=true时，开启附着在顶部；sticky=number时，代表附着顶部，且距离顶部的间距；sticky=StickyProps时，参数将传入 Sticky 组件内。',
+      '头部附着 \n sticky 属性会开启头部附着功能；sticky=true时，开启附着在顶部；sticky=number时，代表附着顶部，且距离顶部的间距；sticky=StickyProps时，参数将传入 Sticky 组件内；switchToTop 属性支持是否自动滚动到Tabs。',
       'Sticky header \n sticky header in Tabs'
     ),
     component: require('doc/pages/components/Tabs/example-13-sticky.js').default,

--- a/site/pages/components/Tabs/cn.md
+++ b/site/pages/components/Tabs/cn.md
@@ -24,7 +24,7 @@
 | lazy | boolean | true | 是否开启懒加载 |
 | autoFill | boolean | false | 自动填充内容区域 |
 | sticky | boolean \| number \| object | - | 开启头部附着 |
-| switchToTop | boolean | - | 切换tab将自动滚动到顶部 |
+| switchToTop | boolean | - | 切换tab将自动滚动到Tabs |
 
 ### Tabs.Panel
 

--- a/site/pages/components/Tabs/cn.md
+++ b/site/pages/components/Tabs/cn.md
@@ -24,6 +24,7 @@
 | lazy | boolean | true | 是否开启懒加载 |
 | autoFill | boolean | false | 自动填充内容区域 |
 | sticky | boolean \| number \| object | - | 开启头部附着 |
+| switchToTop | boolean | - | 切换tab将自动滚动到顶部 |
 
 ### Tabs.Panel
 

--- a/site/pages/components/Tabs/en.md
+++ b/site/pages/components/Tabs/en.md
@@ -24,7 +24,7 @@
 | lazy | boolean | true | lazy load |
 | autoFill | boolean | false | auto fill the panel |
 | sticky | boolean \| number \| object | - | sticky header |
-| switchToTop | boolean | - | switch tabs will scroll to top |
+| switchToTop | boolean | - | switch tabs will scroll to Tabs |
 
 ### Tabs.Panel
 

--- a/site/pages/components/Tabs/en.md
+++ b/site/pages/components/Tabs/en.md
@@ -24,6 +24,7 @@
 | lazy | boolean | true | lazy load |
 | autoFill | boolean | false | auto fill the panel |
 | sticky | boolean \| number \| object | - | sticky header |
+| switchToTop | boolean | - | switch tabs will scroll to top |
 
 ### Tabs.Panel
 

--- a/site/pages/components/Tabs/example-13-sticky.js
+++ b/site/pages/components/Tabs/example-13-sticky.js
@@ -1,6 +1,6 @@
 /**
  * cn - 头部附着
- *    -- sticky 属性会开启头部附着功能；sticky=true时，开启附着在顶部；sticky=number时，代表附着顶部，且距离顶部的间距；sticky=StickyProps时，参数将传入 Sticky 组件内。
+ *    -- sticky 属性会开启头部附着功能；sticky=true时，开启附着在顶部；sticky=number时，代表附着顶部，且距离顶部的间距；sticky=StickyProps时，参数将传入 Sticky 组件内；switchToTop 属性支持是否自动滚动到Tabs。
  * en - Sticky header
  *    -- sticky header in Tabs
  */
@@ -14,7 +14,7 @@ const panelStyle = { padding: '12px 0' }
 
 export default function() {
   return (
-    <Tabs defaultActive={1} sticky tabBarStyle={{ backgroundColor: '#fff' }}>
+    <Tabs defaultActive={1} sticky tabBarStyle={{ backgroundColor: '#fff' }} switchToTop>
       <Tabs.Panel style={panelStyle} tab="Sticky Home">
         {lorem(5)}
       </Tabs.Panel>

--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -22,6 +22,11 @@ class Tabs extends PureComponent {
     this.handleChange = this.handleChange.bind(this)
     this.handleCollapse = this.handleCollapse.bind(this)
     this.renderContent = this.renderContent.bind(this)
+    this.bindContainer = this.bindContainer.bind(this)
+  }
+
+  componentWillUnmount() {
+    this.container = null
   }
 
   getAlign() {
@@ -45,10 +50,18 @@ class Tabs extends PureComponent {
     return this.state.active
   }
 
+  bindContainer(node) {
+    this.container = node
+  }
+
   handleChange(active) {
-    const { onChange } = this.props
+    const { onChange, switchToTop, sticky } = this.props
     if (onChange) onChange(active)
     this.setState({ active })
+    // jump to active panel
+    if (this.container && !isEmpty(sticky) && switchToTop) {
+      this.container.scrollIntoView(true)
+    }
   }
 
   handleCollapse(collapsed) {
@@ -164,7 +177,7 @@ class Tabs extends PureComponent {
     )
 
     return (
-      <div className={className} style={style}>
+      <div className={className} style={style} ref={this.bindContainer}>
         {align !== 'vertical-right' && align !== 'bottom' && this.renderHeader(position)}
         {Children.toArray(children).map(this.renderContent)}
         {(align === 'vertical-right' || align === 'bottom') && this.renderHeader(position)}
@@ -193,6 +206,7 @@ Tabs.propTypes = {
   lazy: PropTypes.bool,
   autoFill: PropTypes.bool,
   sticky: PropTypes.oneOfType([PropTypes.bool, PropTypes.number, PropTypes.object]),
+  switchToTop: PropTypes.bool,
 }
 
 Tabs.defaultProps = {

--- a/src/Tabs/index.d.ts
+++ b/src/Tabs/index.d.ts
@@ -122,6 +122,15 @@ export interface TabsProps extends StandardProps {
    * default: none
    */
   sticky?: boolean | number | StickyProps;
+
+  /**
+   * switch tabs will scroll to top
+   * 
+   * 切换tab将自动滚动到顶部
+   * 
+   * default: nonde
+   */
+  switchToTop?: boolean;
 }
 
 export interface TabsPanelProps extends StandardProps {

--- a/src/Tabs/index.d.ts
+++ b/src/Tabs/index.d.ts
@@ -124,9 +124,9 @@ export interface TabsProps extends StandardProps {
   sticky?: boolean | number | StickyProps;
 
   /**
-   * switch tabs will scroll to top
+   * switch tabs will scroll to Tabs
    * 
-   * 切换tab将自动滚动到顶部
+   * 切换tab将自动滚动到Tabs
    * 
    * default: nonde
    */


### PR DESCRIPTION
需求分析：
- `Tabs`新增 `switchToTop`属性；在使用`sticky`时，切换 tab 支持自动滚动到`Tabs`。