### PR TITLE
fix: input disabled number with no style

### DIFF
--- a/src/hoc/inputBorder.js
+++ b/src/hoc/inputBorder.js
@@ -115,13 +115,14 @@ export default curry(
         const Tag = options.tag || 'label'
 
         const newStyle = Object.assign({ width }, style)
+        const isDisabled = typeof other.disabled === 'function' ? false : !!other.disabled
         const newClassName = classnames(
           inputBorderClass(rtl && 'rtl'),
           inputClass(
             '_',
             rtl && 'rtl',
-            focus && other.disabled !== true && 'focus',
-            other.disabled === true && 'disabled',
+            focus && !isDisabled && 'focus',
+            isDisabled && 'disabled',
             options.isGroup && 'group',
             size,
             newStyle.width && 'inline',


### PR DESCRIPTION
- 问题描述：input disabled={1} 时，未出现禁用样式，但是输入框行为被禁用
- 问题解决：在 inputBorder 中，统一优化 disabled 的样式逻辑：如果为函数，则不设置disabled状态；为其他值则根据具体值来决定是否禁用