### PR TITLE
fix: checkbox cancel value 0

### DIFF
--- a/src/Datum/List.js
+++ b/src/Datum/List.js
@@ -163,7 +163,7 @@ export default class {
   }
 
   remove(value, _, childrenKey) {
-    if (!value) return
+    if (value === undefined || value === null) return
 
     let raws = Array.isArray(value) ? value : [value]
     if (childrenKey) {


### PR DESCRIPTION
- 问题描述：Checkbox htmlValue 为 0 时，无法取消选中
- 问题原因：Datum.List 的 remove() 中使用了 `!value` 判断，导致 0 被过滤
- 问题解决：将 `!value` 修改为 `!== undefined && !== null` 来规避类`false` 值