### PR TITLE
Fix/tabs sticky scroll to top

### DIFF
--- a/src/Sticky/index.js
+++ b/src/Sticky/index.js
@@ -7,6 +7,7 @@ import { getProps, defaultProps } from '../utils/proptypes'
 import { compose } from '../utils/func'
 import { cssSupport, copyBoundingClientRect } from '../utils/dom/element'
 import { docSize } from '../utils/dom/document'
+import { isHidden } from '../utils/is'
 import { consumer } from './context'
 
 const events = ['scroll', 'resize', 'pageshow', 'load']
@@ -78,6 +79,9 @@ class Sticky extends PureComponent {
   setPosition() {
     const { bottom, top, target, css } = this.props
     const { mode, scrollWidth } = this.state
+    // If it is a hidden element, the position will not be updated
+    if (isHidden(this.element)) return
+
     const selfRect = copyBoundingClientRect(this.element)
     const { marginBottom, marginTop } = getComputedStyle(this.element)
     selfRect.height += parseFloat(marginBottom) + parseFloat(marginTop)

--- a/src/Sticky/index.js
+++ b/src/Sticky/index.js
@@ -35,7 +35,7 @@ class Sticky extends PureComponent {
   }
 
   componentDidUpdate(prevProps) {
-    if (!prevProps.neetResetPostion && this.props.neetResetPostion) {
+    if (!prevProps.needResetPostion && this.props.needResetPostion) {
       this.setPosition()
     }
   }
@@ -77,10 +77,10 @@ class Sticky extends PureComponent {
   }
 
   setPosition() {
-    const { bottom, top, target, css } = this.props
+    const { bottom, top, target, css, needResetPostion } = this.props
     const { mode, scrollWidth } = this.state
     // If it is a hidden element, the position will not be updated
-    if (isHidden(this.element)) return
+    if (needResetPostion === false) return
 
     const selfRect = copyBoundingClientRect(this.element)
     const { marginBottom, marginTop } = getComputedStyle(this.element)

--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -8,6 +8,8 @@ import Wrapper from './Wrapper'
 import Sticky from '../Sticky'
 import { tabsClass } from '../styles'
 import { isEmpty, isObject } from '../utils/is'
+import { consumer } from '../Sticky/context'
+import { compose } from '../utils/func'
 
 class Tabs extends PureComponent {
   constructor(props) {
@@ -23,11 +25,19 @@ class Tabs extends PureComponent {
     this.handleCollapse = this.handleCollapse.bind(this)
     this.renderContent = this.renderContent.bind(this)
     this.bindContainer = this.bindContainer.bind(this)
+    this.setStickyStatus = this.setStickyStatus.bind(this)
   }
 
-  componentDidUpdate() {
-    const { sticky, switchToTop } = this.props
-    if (this.container && !isEmpty(sticky) && switchToTop) {
+  componentDidUpdate(prevProps, prevState) {
+    const { sticky, switchToTop, active } = this.props
+
+    if (
+      (prevProps.active !== active || prevState.active !== this.state.active) &&
+      this.container &&
+      !isEmpty(sticky) &&
+      switchToTop &&
+      this.sticky
+    ) {
       // jump to active panel
       this.container.scrollIntoView(true)
     }
@@ -56,6 +66,12 @@ class Tabs extends PureComponent {
   getActive() {
     if ('active' in this.props) return this.props.active
     return this.state.active
+  }
+
+  setStickyStatus(flag) {
+    const { sticky, switchToTop } = this.props
+    if (!sticky || !switchToTop) return
+    this.sticky = flag
   }
 
   bindContainer(node) {
@@ -148,7 +164,11 @@ class Tabs extends PureComponent {
       if (isObject(sticky)) {
         stickyProps = { ...sticky, className: classnames(stickyClassName, sticky.className) }
       }
-      return <Sticky {...stickyProps}>{header}</Sticky>
+      return (
+        <Sticky onChange={this.setStickyStatus} {...stickyProps}>
+          {header}
+        </Sticky>
+      )
     }
     return header
   }
@@ -222,4 +242,4 @@ Tabs.defaultProps = {
   lazy: true,
 }
 
-export default Tabs
+export default compose(consumer)(Tabs)

--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -8,8 +8,6 @@ import Wrapper from './Wrapper'
 import Sticky from '../Sticky'
 import { tabsClass } from '../styles'
 import { isEmpty, isObject } from '../utils/is'
-import { consumer } from '../Sticky/context'
-import { compose } from '../utils/func'
 
 class Tabs extends PureComponent {
   constructor(props) {
@@ -242,4 +240,4 @@ Tabs.defaultProps = {
   lazy: true,
 }
 
-export default compose(consumer)(Tabs)
+export default Tabs

--- a/src/Tabs/Wrapper.js
+++ b/src/Tabs/Wrapper.js
@@ -7,7 +7,7 @@ class Wrapper extends PureComponent {
   render() {
     const { active, id, ...other } = this.props
     return (
-      <Provider value={{ neetResetPostion: id === active }}>
+      <Provider value={{ needResetPostion: id === active }}>
         <Panel {...other} isActive={id === active} />
       </Provider>
     )

--- a/src/utils/is.js
+++ b/src/utils/is.js
@@ -77,3 +77,5 @@ export const isEnterPress = e => e.keyCode === 13
 export const isMacOS = () => /macintosh|mac os x/i.test(navigator.userAgent)
 
 export const isFirefox = () => navigator.userAgent.toLowerCase().indexOf('firefox') > -1
+
+export const isHidden = element => !(element.offsetWidth || element.offsetHeight || element.getClientRects().length)

--- a/src/utils/is.js
+++ b/src/utils/is.js
@@ -77,5 +77,3 @@ export const isEnterPress = e => e.keyCode === 13
 export const isMacOS = () => /macintosh|mac os x/i.test(navigator.userAgent)
 
 export const isFirefox = () => navigator.userAgent.toLowerCase().indexOf('firefox') > -1
-
-export const isHidden = element => !(element.offsetWidth || element.offsetHeight || element.getClientRects().length)


### PR DESCRIPTION
需求分析：
- 优化 `Tabs switchToTop` 切换 `tab` 自动滚动到顶部；优化方案：在滚动判断条件新增只有 `sticky` 的时候，才执行滚动操作。