### PR TITLE
Table select

### DIFF
--- a/src/Table/CheckboxAll.js
+++ b/src/Table/CheckboxAll.js
@@ -27,23 +27,11 @@ export default class extends PureComponent {
     this.props.datum.unsubscribe(CHANGE_TOPIC, this.handleUpdate)
   }
 
-  check(d) {
-    const { datum } = this.props
-    const p = datum.check(d)
-    if (!p) return false
-    if (d.children) {
-      for (const c of d.children) {
-        if (!this.check(c)) return false
-      }
-    }
-    return true
-  }
-
   getChecked() {
     const { data, datum } = this.props
     if (datum.length === 0 || !data) return false
 
-    let checked = true
+    const checked = true
     for (const d of data) {
       if (datum.disabled(d)) continue
       const p = this.check(d)
@@ -53,6 +41,20 @@ export default class extends PureComponent {
     }
 
     return checked
+  }
+
+  check(d) {
+    const { datum, treeColumnsName } = this.props
+    const p = datum.check(d)
+    if (!p) return false
+    const children = d[treeColumnsName]
+    const isArray = children && Array.isArray(children)
+    if (isArray) {
+      for (const c of children) {
+        if (!this.check(c)) return false
+      }
+    }
+    return true
   }
 
   handleChange(_, checked, index) {

--- a/src/Table/CheckboxAll.js
+++ b/src/Table/CheckboxAll.js
@@ -27,17 +27,27 @@ export default class extends PureComponent {
     this.props.datum.unsubscribe(CHANGE_TOPIC, this.handleUpdate)
   }
 
+  check(d) {
+    const { datum } = this.props
+    const p = datum.check(d)
+    if (!p) return false
+    if (d.children) {
+      for (const c of d.children) {
+        if (!this.check(c)) return false
+      }
+    }
+    return true
+  }
+
   getChecked() {
     const { data, datum } = this.props
     if (datum.length === 0 || !data) return false
 
-    let checked
+    let checked = true
     for (const d of data) {
       if (datum.disabled(d)) continue
-      const p = datum.check(d)
-      if (checked === undefined) {
-        checked = p
-      } else if (checked !== p) {
+      const p = this.check(d)
+      if (checked !== p) {
         return 'indeterminate'
       }
     }


### PR DESCRIPTION
- 问题描述：Table 行选择的树形数据下，如果选中了子数据并发生了折叠，表头的Checkbox会变为未选中
- 问题解决：表头的Checkbox状态未考虑到子数据的状态，增加了子数据状态显示的逻辑