### PR TITLE
fix: input.number blur with onchange

### DIFF
--- a/src/Input/Number.js
+++ b/src/Input/Number.js
@@ -49,8 +49,7 @@ class Number extends PureComponent {
     if (max !== undefined && value > max) value = max
     if (min !== undefined && value < min) value = min
 
-    // some values are number
-    if (value.toString() !== this.props.value) {
+    if (value !== this.props.value) {
       this.props.onChange(value)
     }
   }

--- a/src/utils/validate/rangeLength.js
+++ b/src/utils/validate/rangeLength.js
@@ -10,11 +10,10 @@ export default options => (value, formdata, callback) => {
     return
   }
 
-  const len = value.length
+  const len = typeof value !== 'string' ? value.toString().length : value.length
   if ((typeof min === 'number' && len < min) || (typeof max === 'number' && len > max)) {
     callback(error)
   } else {
     callback(true)
   }
 }
-


### PR DESCRIPTION
- 问题描述：Input.Number 从 1.6.3-rc.25 后 失去焦点并不会触发`number` 类型的`onChange`，导致原有的代码逻辑失效。
- 问题原因：在 rc.25 中（#1000 ），为了解决失去焦点会使用`number`类型值清空校验信息的问题，将原有的 `onChange `给屏蔽了。导致修改了原有的逻辑。
- 问题解决：在 rules 的 rangeLength 逻辑中，添加了针对`number`类型值的长度校验。