### PR TITLE
fix: select onfilter paste

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shineout",
-  "version": "1.6.3-rc.44",
+  "version": "1.6.3-rc.45",
   "description": "Shein 前端组件库",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/site/pages/documentation/changelog-rc/1.x.x.md
+++ b/site/pages/documentation/changelog-rc/1.x.x.md
@@ -1,5 +1,9 @@
 # 更新日志
 
+### 1.6.3-rc.45
+ - Select 输入内容超长支持换行
+ - 修复 Select onFilter 黏贴时内容不正确的问题
+
 ### 1.6.3-rc.43
  - 优化 TypeScript 提示
  - 修复 Input.Number 失去焦点不触发 onChange 的问题

--- a/src/Select/Input.js
+++ b/src/Select/Input.js
@@ -8,6 +8,13 @@ const handleFocus = e => {
   e.stopPropagation()
 }
 
+const handlePaste = e => {
+  const text = (e.clipboardData || window.clipboardData).getData('text/plain')
+  if (!text) return
+  e.preventDefault()
+  document.execCommand('insertText', false, text)
+}
+
 class FilterInput extends Component {
   constructor(props) {
     super(props)
@@ -19,7 +26,6 @@ class FilterInput extends Component {
     this.bindElement = this.bindElement.bind(this)
     this.handleInput = this.handleInput.bind(this)
     this.handleBlur = this.handleBlur.bind(this)
-    this.handlePaste = this.handlePaste.bind(this)
 
     this.focusInput = this.focusInput.bind(this)
 
@@ -86,6 +92,7 @@ class FilterInput extends Component {
   }
 
   handleInput(e) {
+    console.log('input: ', e.target.innerText)
     const text = e.target.innerText.replace('\feff ', '')
     this.lastCursorOffset = getCursorOffset(text.length)
     const t = this.getProcessedValue(text)
@@ -100,14 +107,6 @@ class FilterInput extends Component {
     this.props.onInputBlur(text)
   }
 
-  handlePaste(e) {
-    const text = (e.clipboardData || window.clipboardData).getData('text/plain')
-    if (!text) return
-    e.preventDefault()
-    document.execCommand('insertText', false, text)
-    this.handleInput({ target: { innerText: text } })
-  }
-
   render() {
     const { text, focus, multiple } = this.props
     const value = typeof text === 'string' ? text.replace(/<\/?[^>]*>/g, '') : text
@@ -120,7 +119,7 @@ class FilterInput extends Component {
       contentEditable: focus || this.state.editable,
       onFocus: handleFocus,
       onBlur: this.handleBlur,
-      onPaste: this.handlePaste,
+      onPaste: handlePaste,
       title: !focus && isString(value) ? value : null,
     }
 

--- a/src/Select/Input.js
+++ b/src/Select/Input.js
@@ -92,7 +92,6 @@ class FilterInput extends Component {
   }
 
   handleInput(e) {
-    console.log('input: ', e.target.innerText)
     const text = e.target.innerText.replace('\feff ', '')
     this.lastCursorOffset = getCursorOffset(text.length)
     const t = this.getProcessedValue(text)

--- a/src/styles/select.less
+++ b/src/styles/select.less
@@ -49,7 +49,7 @@
       margin-bottom: @padding-base-vertical;
       outline: none;
       cursor: text;
-      white-space: pre;
+      white-space: pre-wrap;
 
       &:after {
         content: '\feff ';

--- a/src/styles/treeSelect.less
+++ b/src/styles/treeSelect.less
@@ -83,7 +83,7 @@
       flex: 1;
       margin-bottom: @padding-base-vertical;
       outline: none;
-      white-space: pre;
+      white-space: pre-wrap;
 
       &:after {
         content: '\feff ';


### PR DESCRIPTION
- 问题描述：Select/TreeSelect 可输入的时候，再输入过程中文字过长时滚动条会遮住文字。
- 问题解决：当文字超长时，自动换行

- 问题描述：Select 可筛选的时候，黏贴入内容不会触发新值的 onFilter
- 问题解决：handlePaste 中不再调用 onFilter，统一放到 onInput 中进行执行