### PR TITLE
fix: cascader disabled hide clear icon

### DIFF
--- a/src/styles/cascader.less
+++ b/src/styles/cascader.less
@@ -122,9 +122,11 @@
     cursor: not-allowed;
   }
 
-  &-focus &-close,
-  &-result:hover &-close {
-    display: block;
+  &:not(&-disabled) {
+    &-focus &-close,
+    &-result:hover &-close {
+      display: block;
+    }
   }
 
   &-multiple {


### PR DESCRIPTION
- 问题描述：Cascader disabled 的时候，clearable 还能够生效
- 问题解决：disabled 时，隐藏 clear icon，使 clear 功能禁用