### PR TITLE
feat: upload add request ignore example

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shineout",
-  "version": "1.6.3-rc.45",
+  "version": "1.6.3-rc.46",
   "description": "Shein 前端组件库",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/site/chunks/Components/Upload.js
+++ b/site/chunks/Components/Upload.js
@@ -86,13 +86,22 @@ const examples = [
     rawText: require('!raw-loader!doc/pages/components/Upload/example-06-error.js'),
   },
   {
-    name: '08-request',
+    name: '08-request-a',
     title: locate(
       '自定义上传 \n 通过 request 函数，替代默认上传方法',
       'Custom Request \n Set request property to use your own XMLHttpRequest.'
     ),
-    component: require('doc/pages/components/Upload/example-08-request.js').default,
-    rawText: require('!raw-loader!doc/pages/components/Upload/example-08-request.js'),
+    component: require('doc/pages/components/Upload/example-08-request-a.js').default,
+    rawText: require('!raw-loader!doc/pages/components/Upload/example-08-request-a.js'),
+  },
+  {
+    name: '08-request-ignore',
+    title: locate(
+      ' \n 使用 request 略过上传过程',
+      ' \n ignore request with request'
+    ),
+    component: require('doc/pages/components/Upload/example-08-request-ignore.js').default,
+    rawText: require('!raw-loader!doc/pages/components/Upload/example-08-request-ignore.js'),
   },
   {
     name: '09-zip',

--- a/site/pages/components/Upload/example-08-request-a.js
+++ b/site/pages/components/Upload/example-08-request-a.js
@@ -34,7 +34,8 @@ export default function() {
       renderResult={d => d.name}
     >
       <Button>
-        <FontAwesome name="upload" /> Upload file
+        <FontAwesome name="upload" />
+        &nbsp;Upload file
       </Button>
     </Upload>
   )

--- a/site/pages/components/Upload/example-08-request-ignore.js
+++ b/site/pages/components/Upload/example-08-request-ignore.js
@@ -1,0 +1,31 @@
+/**
+ * cn -
+ *    -- 使用 request 略过上传过程
+ * en -
+ *    -- ignore request with request
+ */
+import React from 'react'
+import { Upload } from 'shineout'
+
+const request = options => {
+  const { file, onLoad, onError } = options
+  const reader = new FileReader()
+  reader.addEventListener('load', () => {
+    onLoad({ status: 200, response: reader.result })
+  })
+  reader.addEventListener('error', () => {
+    onError({ statusText: 'Oops, something went wrong' })
+  })
+  reader.readAsDataURL(file)
+}
+
+export default function() {
+  return (
+    <Upload.Image
+      accept="image/*"
+      onSuccess={(dataURL, file) => ({ name: file.name, src: dataURL })}
+      request={request}
+      renderResult={d => d.src}
+    />
+  )
+}

--- a/site/pages/documentation/changelog-rc/1.x.x.md
+++ b/site/pages/documentation/changelog-rc/1.x.x.md
@@ -1,5 +1,10 @@
 # 更新日志
 
+### 1.6.3-rc.46
+ - Upload 新增单独展示图片的例子
+ - DatePicker 新增 defaultPickerValue，用于设置面板的时间
+ - 修复 Cascader disabled 下还能清空值的问题
+
 ### 1.6.3-rc.45
  - Select 输入内容超长支持换行
  - 修复 Select onFilter 黏贴时内容不正确的问题

--- a/test/src/Upload/__snapshots__/example.spec.js.snap
+++ b/test/src/Upload/__snapshots__/example.spec.js.snap
@@ -129,15 +129,26 @@ exports[`Snapshot test: Upload[site/pages/components/Upload/example-06-error.js]
 </div>
 `;
 
-exports[`Snapshot test: Upload[site/pages/components/Upload/example-08-request.js] 1`] = `
+exports[`Snapshot test: Upload[site/pages/components/Upload/example-08-request-a.js] 1`] = `
 <div>
   <span>
     <button>
       <i />
       <span>
-         Upload file
+         Upload file
       </span>
     </button>
+    <input />
+  </span>
+</div>
+`;
+
+exports[`Snapshot test: Upload[site/pages/components/Upload/example-08-request-ignore.js] 1`] = `
+<div>
+  <span>
+    <div>
+      <div />
+    </div>
     <input />
   </span>
 </div>


### PR DESCRIPTION
- 需求描述：Upload.Image 新增如何不发送网络请求来获取文件的例子
- 需求实现：在 request 中使用 FileReader 来将 blob 转换成 dataURL，转换成功后 通过 `onLoad` 来模拟上传成功的操作。