### PR TITLE
Feat/upload ignore preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shineout",
-  "version": "1.6.3-rc.50",
+  "version": "1.6.3-rc.51",
   "description": "Shein 前端组件库",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/site/pages/components/Upload/cn.md
+++ b/site/pages/components/Upload/cn.md
@@ -51,6 +51,8 @@
 | onErrorRemove | (xhr: XMLHttpRequest, file: Blob) => void | none | 上传失败图片删除之后的回调 |
 | leftHandler | boolean | false | 添加图片视图是否在左侧展示 |
 | onPreview | (url, value, index, values) => void | none | 预览图片操作，默认为画廊展示 |
+| ignorePreview | boolean | false | 是否忽略上传图片预览 |
+
 ### Upload.Button
 
 | 属性 | 类型 | 默认值 | 说明 |

--- a/site/pages/components/Upload/en.md
+++ b/site/pages/components/Upload/en.md
@@ -46,6 +46,7 @@
 | renderResult | (data: any) => ReactNode | a => a | Return the link address of the url of the image.|
 | onErrorRemove | (xhr: XMLHttpRequest, file: Blob) => void | none | remove update failed callback |
 | onPreview | (url, value, index, values) => void | none | how to preview the image |
+| ignorePreview | boolean | false | ignore image preview |
 
 ### Upload.Button
 

--- a/site/pages/documentation/changelog-rc/1.x.x.md
+++ b/site/pages/documentation/changelog-rc/1.x.x.md
@@ -1,5 +1,8 @@
 # 更新日志
 
+### 1.6.3-rc.51
+ - Upload.Image 新增 ignorePreview 来忽略预览验证
+
 ### 1.6.3-rc.50
  - 修复 Cascader value 和 data 同时更新时不生效的问题
 

--- a/src/Upload/Image.js
+++ b/src/Upload/Image.js
@@ -67,7 +67,7 @@ class Image extends PureComponent {
   }
 
   render() {
-    const { children, width, height, ...others } = this.props
+    const { children, width, height, ignorePreview, ...others } = this.props
     const { urlInvalid } = this.state
     if (urlInvalid) {
       clearTimeout(this.timeout)
@@ -80,7 +80,7 @@ class Image extends PureComponent {
     const content = children || <div className={uploadClass('indicator', urlInvalid && 'url-invalid-indicator')} />
 
     return (
-      <Upload {...others} imageStyle={style} beforeUpload={this.beforeUpload}>
+      <Upload {...others} imageStyle={style} beforeUpload={ignorePreview ? undefined : this.beforeUpload}>
         <div
           tabIndex={this.props.disabled ? -1 : 0}
           style={style}
@@ -116,6 +116,7 @@ Image.propTypes = {
   }),
   width: PropTypes.number,
   disabled: PropTypes.bool,
+  ignorePreview: PropTypes.bool,
 }
 
 Image.defaultProps = {

--- a/src/Upload/index.d.ts
+++ b/src/Upload/index.d.ts
@@ -350,6 +350,15 @@ export interface UploadImageProps<T> extends UploadProps<T>{
    */
   onPreview?:(url: string, value: T, index: number, values: T[]) => void;
 
+  /**
+   * ignore image preview 
+   * 
+   * 是否忽略上传图片预览
+   * 
+   * defualt: false
+   */
+  ignorePreview?: boolean;
+
 }
 
 export interface UploadButtonProps<T> extends UploadProps<T> {


### PR DESCRIPTION
- 需求描述：Image.Upload 默认会校验上传文件是否能够预览，有些场景需要跳过这个步骤
- 需求实现：提供 ignorePreview 属性来跳过预览验证操作