### PR TITLE
fix: update responseType

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shineout",
-  "version": "1.6.3-rc.51",
+  "version": "1.6.3-rc.52",
   "description": "Shein 前端组件库",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/site/pages/documentation/changelog-rc/1.x.x.md
+++ b/site/pages/documentation/changelog-rc/1.x.x.md
@@ -1,5 +1,8 @@
 # 更新日志
 
+### 1.6.3-rc.52
+ - 修复 Upload 自定义请求 指定 responseType 后报错的问题
+
 ### 1.6.3-rc.51
  - Upload.Image 新增 ignorePreview 来忽略预览验证
 

--- a/src/Upload/Upload.js
+++ b/src/Upload/Upload.js
@@ -291,7 +291,10 @@ class Upload extends PureComponent {
           return
         }
 
-        let value = xhr.responseText || xhr.response
+        let value
+        if (xhr.responseType === 'text' || !xhr.responseType) value = xhr.responseText
+        else value = xhr.response
+
         if (onSuccess) {
           value = onSuccess(value, file, data, xhr)
         }


### PR DESCRIPTION
- 问题描述：Upload 自定义 request 时，将 responseType 设置为 `text` 意外的其他值时，会抛出异常
- 问题原因：Chrome 下 responseType 为非 `text` 时，xhr.responseText 会是异常值，导致读取的时候抛错。Firefox 下因为没有 responseText 字段而直接获取了  response（没有抛错）
- 问题解决：在取值的时候根据 reseponseType 来取