### PR TITLE
fix: reset clear validate

### DIFF
--- a/src/Datum/Form.js
+++ b/src/Datum/Form.js
@@ -45,7 +45,7 @@ export default class {
   }
 
   reset() {
-    this.$errors = {}
+    this.validateClear()
     this.setValue(unflatten(fastClone(this.$defaultValues)), FORCE_PASS, true)
     this.handleChange()
     this.dispatch(RESET_TOPIC)

--- a/src/Datum/Form.js
+++ b/src/Datum/Form.js
@@ -45,7 +45,7 @@ export default class {
   }
 
   reset() {
-    this.validateClear()
+    this.$errors = {}
     this.setValue(unflatten(fastClone(this.$defaultValues)), FORCE_PASS, true)
     this.handleChange()
     this.dispatch(RESET_TOPIC)

--- a/src/Form/inputable.js
+++ b/src/Form/inputable.js
@@ -275,7 +275,6 @@ export default curry(Origin =>
               })
             })
 
-        console.log(this.errorChange)
         if (!this.errorChange && shallowEqual(newValue, this.lastValue)) return
         this.lastValue = newValue
 

--- a/src/Form/inputable.js
+++ b/src/Form/inputable.js
@@ -176,6 +176,10 @@ export default curry(Origin =>
           this.setState({ error })
         }
 
+        const hasError = error !== undefined
+        this.errorChange = hasError !== this.lastError
+        this.lastError = hasError
+
         if (onError) onError(error)
         if (onItemError && !name) onItemError(this.itemName, error)
       }
@@ -271,7 +275,8 @@ export default curry(Origin =>
               })
             })
 
-        if (shallowEqual(newValue, this.lastValue)) return
+        console.log(this.errorChange)
+        if (!this.errorChange && shallowEqual(newValue, this.lastValue)) return
         this.lastValue = newValue
 
         if (type === FORCE_PASS) {


### PR DESCRIPTION
- 问题描述：Form reset 方法，在多次清空-校验-清空-校验后，inputable的校验信息未更新，具体示例见 [codesandbox](https://codesandbox.io/s/flamboyant-paper-2hmcf)
- 问题原因：inputable 中 `handleUpdate` 做了 value 的 shallowEqual，但是未考虑到校验信息的变化
- 问题解决：在 inputable 中加入校验信息变化的处理