### PR TITLE
fix: sticky support chrome scale

### DIFF
--- a/src/Sticky/index.js
+++ b/src/Sticky/index.js
@@ -114,7 +114,7 @@ class Sticky extends PureComponent {
     }
 
     if (top !== undefined && mode !== 'bottom') {
-      if (selfRect.top < limitTop) {
+      if (Math.ceil(selfRect.top) < limitTop) {
         this.setState({ scrollWidth: scrollRect.width, mode: 'top' })
         style = this.getStyle('top', top, selfRect.left, selfRect.width)
         placeholder = placeholderStyle


### PR DESCRIPTION
- 问题描述：在 chrome 中对浏览器进行缩放后，如果 Sticky 的 `top * 缩放比例` 是一个小数的话，会出现 getBoudingClientRect.top 与 实际值不一致的情况，导致异常。
- 问题解决：将 getBoudingClientRect.top 与向上对齐