### PR TITLE
fix: change merge to clone

### DIFF
--- a/src/Datum/Form.js
+++ b/src/Datum/Form.js
@@ -1,7 +1,7 @@
 import deepEqual from 'deep-eql'
 import { unflatten, insertValue, spliceValue, getSthByName } from '../utils/flat'
 import { fastClone, deepClone } from '../utils/clone'
-import { deepGet, deepSet, deepRemove, deepMerge, objectValues, deepHas } from '../utils/objects'
+import { deepGet, deepSet, deepRemove, objectValues, deepHas } from '../utils/objects'
 import { isObject, isArray } from '../utils/is'
 import { promiseAll, FormError } from '../utils/errors'
 import {
@@ -207,7 +207,7 @@ export default class {
 
   setValue(values = {}, type, forceSet) {
     if (!forceSet && deepEqual(values, this.$values)) return
-    this.$values = deepMerge({}, values, { clone: true })
+    this.$values = deepClone(values)
 
     // wait render end.
     setTimeout(() => {


### PR DESCRIPTION
#1124 
- 问题原因：Form中的array类型数据在经过setValue中时，deepMerge不会进行clone，导致修改了Form的value，外界的引用值发生变化
- 问题解决：将datum/form.js setValue 中的deepMerge变成deepClone