### PR TITLE
fix: 修复Modal从弹窗拖拽到蒙层会触发点击事件到问题

### DIFF
--- a/src/Modal/Panel.js
+++ b/src/Modal/Panel.js
@@ -33,7 +33,8 @@ export default class Panel extends PureComponent {
   constructor(props) {
     super(props)
     this.handleClose = this.handleClose.bind(this)
-    this.saveTarget = this.saveTarget.bind(this)
+    this.handleMaskDown = this.handleMaskClick.bind(this, 'maskDownTarget')
+    this.handleMaskUp = this.handleMaskClick.bind(this, 'maskUpTarget')
   }
 
   componentDidMount() {
@@ -114,21 +115,16 @@ export default class Panel extends PureComponent {
     event.preventDefault()
   }
 
-  saveTarget(e) {
-    // 通过保存mousedown 和 mouseup 的对象 来避免拖拽点击事件
-    if (e.type === 'mousedown') {
-      this.mouseDownTarget = e.target
-    }
-    if (e.type === 'mouseup') {
-      this.mouseUpTarget = e.target
-    }
+  handleMaskClick(type, e) {
+    this[type] = e.target
   }
 
-  handleClose() {
+  handleClose(e) {
     const { maskCloseAble, onClose } = this.props
+    const { target } = e
     if (!maskCloseAble) return
-    if (!this.mouseDownTarget || !this.mouseDownTarget.matches(`.${modalClass('mask')}`)) return
-    if (this.mouseUpTarget && this.mouseUpTarget.matches(`.${modalClass('mask')}`) && onClose) onClose()
+    if (this.maskDownTarget !== this.maskUpTarget) return
+    if (target.matches(`.${modalClass('mask')}`) && onClose) onClose()
   }
 
   renderIcon() {
@@ -213,8 +209,8 @@ export default class Panel extends PureComponent {
             {...events}
             style={maskStyle}
             className={modalClass('mask')}
-            onMouseDown={this.saveTarget}
-            onMouseUp={this.saveTarget}
+            onMouseDown={this.handleMaskDown}
+            onMouseUp={this.handleMaskUp}
             onClick={this.handleClose}
           >
             <Card

--- a/src/Modal/Panel.js
+++ b/src/Modal/Panel.js
@@ -33,6 +33,7 @@ export default class Panel extends PureComponent {
   constructor(props) {
     super(props)
     this.handleClose = this.handleClose.bind(this)
+    this.saveTarget = this.saveTarget.bind(this)
   }
 
   componentDidMount() {
@@ -113,11 +114,21 @@ export default class Panel extends PureComponent {
     event.preventDefault()
   }
 
-  handleClose(e) {
+  saveTarget(e) {
+    // 通过保存mousedown 和 mouseup 的对象 来避免拖拽点击事件
+    if (e.type === 'mousedown') {
+      this.mouseDownTarget = e.target
+    }
+    if (e.type === 'mouseup') {
+      this.mouseUpTarget = e.target
+    }
+  }
+
+  handleClose() {
     const { maskCloseAble, onClose } = this.props
-    const { target } = e
     if (!maskCloseAble) return
-    if (target.matches(`.${modalClass('mask')}`) && onClose) onClose()
+    if (!this.mouseDownTarget || !this.mouseDownTarget.matches(`.${modalClass('mask')}`)) return
+    if (this.mouseUpTarget && this.mouseUpTarget.matches(`.${modalClass('mask')}`) && onClose) onClose()
   }
 
   renderIcon() {
@@ -198,7 +209,14 @@ export default class Panel extends PureComponent {
     return (
       <ZProvider value>
         <Provider value={{ element: undefined }}>
-          <div {...events} style={maskStyle} className={modalClass('mask')} onClick={this.handleClose}>
+          <div
+            {...events}
+            style={maskStyle}
+            className={modalClass('mask')}
+            onMouseDown={this.saveTarget}
+            onMouseUp={this.saveTarget}
+            onClick={this.handleClose}
+          >
             <Card
               forwardedRef={this.savePanel}
               moveable={moveable}

--- a/test/src/Modal/Modal.mask.spec.js
+++ b/test/src/Modal/Modal.mask.spec.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import { Modal } from 'shineout'
 import { mount } from 'enzyme'
-import { dispatchEvent } from '../../../src/utils/dom/element'
 
 /* global SO_PREFIX */
 class ModalMask extends React.Component {
@@ -9,11 +8,13 @@ class ModalMask extends React.Component {
     maskCloseAble: false,
     visible: true,
   }
+
   handleCancel = () => {
     this.setState({
       visible: false,
     })
   }
+
   render() {
     const { visible, maskCloseAble } = this.state
     return <Modal visible={visible} maskCloseAble={maskCloseAble} title="Modal Title" onClose={this.handleCancel} />
@@ -22,12 +23,16 @@ class ModalMask extends React.Component {
 
 describe('Modal[mask]', () => {
   test('should match maskCloseAble', () => {
-    function expectResult(closeBtn, modalShow){
+    function expectResult(closeBtn, modalShow) {
       jest.runAllTimers()
-      expect(document.getElementsByClassName(`${SO_PREFIX}-modal-close`).length).toBe(closeBtn ? 1: 0)
+      expect(document.getElementsByClassName(`${SO_PREFIX}-modal-close`).length).toBe(closeBtn ? 1 : 0)
+      const down = new MouseEvent('mousedown', { view: window, cancelable: true, bubbles: true })
+      document.querySelector(`.${SO_PREFIX}-modal-mask`).dispatchEvent(down)
+      const up = new MouseEvent('mouseup', { view: window, cancelable: true, bubbles: true })
+      document.querySelector(`.${SO_PREFIX}-modal-mask`).dispatchEvent(up)
       document.querySelector(`.${SO_PREFIX}-modal-mask`).click()
       jest.runAllTimers()
-      expect(document.getElementsByClassName(`${SO_PREFIX}-modal-show`).length).toBe(modalShow ? 1: 0)
+      expect(document.getElementsByClassName(`${SO_PREFIX}-modal-show`).length).toBe(modalShow ? 1 : 0)
     }
     jest.useFakeTimers()
     const wrapper = mount(<ModalMask />)


### PR DESCRIPTION
问题描述： 从弹窗拖拽到蒙版，或者从蒙版拖拽到弹窗会导致弹窗关闭。
解决办法： 保存mouseup 和 mousedown 的对象在click事件中进行判断