### PR TITLE
fix: 修复Modal同时打开一个和关闭一个Modal时候，蒙层透明度计算错误的问题

### DIFF
--- a/src/Modal/events.js
+++ b/src/Modal/events.js
@@ -41,12 +41,25 @@ export function destroy(id, unmount) {
   container.removeChild(div)
 }
 
+function updateMask({ maskOpacity }) {
+  const ids = Object.keys(containers).filter(k => containers[k].visible)
+  if (ids.length) {
+    const outer = containers[ids[0]]
+    const opacityDefault = maskOpacity === undefined ? 0.25 : maskOpacity
+    if (outer.opacity !== opacityDefault) {
+      outer.opacity = opacityDefault
+      outer.div.style.backgroundColor = `rgba(0, 0, 0, ${opacityDefault})`
+    }
+  }
+}
+
 export function close(props, callback) {
-  const { id } = props
+  const { id, maskOpacity } = props
   const modal = containers[props.id]
 
   if (!modal || modal.visible === false) return
   modal.visible = false
+  updateMask({ maskOpacity })
 
   const { div } = modal
   div.classList.remove(modalClass('show'), modalClass('start'))
@@ -102,7 +115,7 @@ export function open(props, isPortal) {
   const opacityDefault = props.maskOpacity === undefined ? 0.25 : props.maskOpacity
   const maskOpacity = isMask(props.id) ? opacityDefault : 0.01
   div.style.background = props.maskBackground || `rgba(0,0,0,${maskOpacity})`
-
+  containers[props.id].opacity = maskOpacity
   containers[props.id].visible = true
 
   const panel = (


### PR DESCRIPTION
问题描述: 同时打开和关闭一个Modal，打开的Modal 会认为自己是在上层使得透明度计算失败
解决办法：关闭的时候再次更新透明度