### PR TITLE
fix: Tree设置 dragSibling 限制兄弟节点之间拖动,当只有一个节点当时候draging变量计算有问题

### DIFF
--- a/src/Tree/Node.js
+++ b/src/Tree/Node.js
@@ -149,9 +149,9 @@ class Node extends PureComponent {
 
   handleDragEnd() {
     this.element.style.display = ''
-
-    if (!isDragging || !placeElement.parentNode) return
+    if (!isDragging) return
     isDragging = false
+    if (!placeElement.parentNode) return
 
     document.body.removeChild(this.dragImage)
 


### PR DESCRIPTION
问题描述： dragSibling 限制兄弟节点之间拖动, 当没有兄弟节点的时候dragEnd 结束后isDrag 变量没有置为false 导致后续drag 无法生效。
解决办法： 调整dragEnd 中 修改isDrag的逻辑