### PR TITLE
fix: menu active

### DIFF
--- a/src/Menu/Root.js
+++ b/src/Menu/Root.js
@@ -371,7 +371,6 @@ Root.defaultProps = {
   keygen: 'id',
   mode: 'inline',
   inlineIndent: 24,
-  active: () => false,
   renderItem: 'title',
   defaultOpenKeys: [],
   onClick: () => true,


### PR DESCRIPTION
需求分析：
 - [不写 active 属性下，永远 false](https://codesandbox.io/s/silly-cloud-2hv9y?file=/App.js)

解决：
 因为`active` 在 `Root.js ` 下，有一个 `defaultProps: () => false`，移除即可。