### PR TITLE
fix: table cell divider in chrome91&safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shineout",
-  "version": "1.6.5-rc.9",
+  "version": "1.6.5-rc.10",
   "description": "Shein 前端组件库",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/site/pages/documentation/changelog-rc/1.x.x.md
+++ b/site/pages/documentation/changelog-rc/1.x.x.md
@@ -1,5 +1,9 @@
 # 更新日志
 
+### 1.6.5-rc.10
+ - Input onEnterPress 调整为抬起后触发
+ - 修复 Table 在 Chrome91 和 Safari 下鼠标悬浮在 Tr 上出现白色分割线的问题
+
 ### 1.6.5-rc.9
  - 修复 Menu 不设置 active 情况下无法选中的问题
  - Select/Dropdown 等组件中下拉箭头支持动态设置

--- a/src/styles/table.less
+++ b/src/styles/table.less
@@ -24,7 +24,6 @@
     z-index: 10;
     width: 100%;
     height: 100%;
-    background: #fff;
     opacity: 0;
     transition: all 0.3s;
     content: '';
@@ -217,6 +216,7 @@
   }
 
   &-hover {
+    table > tbody > tr:hover,
     table > tbody > tr:hover > td {
       background-color: @table-bg-hover;
     }


### PR DESCRIPTION
- 修复在 chrome91 和 safari 下， Table hover tr 时，单元格之间有白色边框的问题