### PR TITLE
fix: table border-overlapping

### DIFF
--- a/src/Table/Tbody.js
+++ b/src/Table/Tbody.js
@@ -19,29 +19,6 @@ function ignoreBorderRight(rows) {
   })
 }
 
-function ignoreBorderBottom(rows) {
-  const emptyColumn = {}
-  const lastLine = rows[rows.length - 1]
-  if (!lastLine) return
-  lastLine.forEach((column, index) => {
-    if (column === null) {
-      emptyColumn[index] = true
-    }
-  })
-  if (Object.keys(emptyColumn).length === 0) return
-  for (let i = rows.length - 2; i >= 0; i--) {
-    const row = rows[i]
-    Object.keys(emptyColumn).forEach(emptyIndex => {
-      const index = parseInt(emptyIndex, 10)
-      if (row[index]) {
-        row[index].ignoreBorderBottom = true
-        delete emptyColumn[emptyIndex]
-      }
-    })
-    if (row.indexOf(null) === -1) break
-  }
-}
-
 function format(columns, data, nextRow, index, expandKeys) {
   const row = columns.map((col, i) => {
     const cell = { index, data, expandKeys }
@@ -232,7 +209,6 @@ class Tbody extends PureComponent {
     }
 
     if (rows.length > 0 && bordered) {
-      ignoreBorderBottom(rows)
       ignoreBorderRight(rows)
     }
     this.keys = {}

--- a/src/Table/Td.js
+++ b/src/Table/Td.js
@@ -115,18 +115,7 @@ class Td extends PureComponent {
   }
 
   render() {
-    const {
-      rowSpan,
-      colSpan,
-      fixed,
-      style,
-      firstFixed,
-      lastFixed,
-      type,
-      align,
-      ignoreBorderRight,
-      ignoreBorderBottom,
-    } = this.props
+    const { rowSpan, colSpan, fixed, style, firstFixed, lastFixed, type, align, ignoreBorderRight } = this.props
 
     const className = classnames(
       this.props.className,
@@ -137,8 +126,7 @@ class Td extends PureComponent {
         lastFixed && 'fixed-last',
         (type === 'checkbox' || type === 'expand' || type === 'row-expand') && 'checkbox',
         align !== 'left' && `align-${align}`,
-        ignoreBorderRight && 'ignore-right-border',
-        ignoreBorderBottom && 'ignore-bottom-border'
+        ignoreBorderRight && 'ignore-right-border'
       )
     )
 
@@ -170,7 +158,6 @@ Td.propTypes = {
   datum: PropTypes.object,
   render: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   ignoreBorderRight: PropTypes.bool,
-  ignoreBorderBottom: PropTypes.bool,
   treeColumnsName: PropTypes.string,
   onTreeExpand: PropTypes.func,
   treeExpand: PropTypes.bool,

--- a/src/styles/table.less
+++ b/src/styles/table.less
@@ -248,10 +248,21 @@
     position: relative;
     border-left: 1px solid @table-border-color;
     border-right: 1px solid @table-border-color;
-    border-bottom: 1px solid @table-border-color;
     border-top: 1px solid @table-border-color;
 
-    .@{table-prefix}-ignore-right-border, @{table-prefix}-ignore-bottom-border {
+    &:before {
+      position: absolute;
+      content: '';
+      display: inline-block;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      height: 1px;
+      background: @table-border-color;
+      z-index: 100;
+    }
+
+    .@{table-prefix}-ignore-right-border {
       border-right: none;
 
       &:before {


### PR DESCRIPTION
- 问题描述：去除 ignore-border-bottom 后（因为要实现table数据少的情况下最后一行不能没有边框），Table 设置 bordered 后， 最后一行 tr 的下边框会与table的下边框重叠。
- 问题解决：将Table的border-bottom使用before来实现