### PR TITLE
fix: table border-bttom z-index

### DIFF
--- a/src/styles/table.less
+++ b/src/styles/table.less
@@ -246,6 +246,7 @@
 
   &-bordered {
     position: relative;
+    z-index: 1;
     border-left: 1px solid @table-border-color;
     border-right: 1px solid @table-border-color;
     border-top: 1px solid @table-border-color;


### PR DESCRIPTION
- borderer table 外层创建层叠上下文，避免内部元素的z-index影响其他dom节点