### PR TITLE
Feat/upload drag

### DIFF
--- a/site/pages/components/Upload/example-10-defaultValue.js
+++ b/site/pages/components/Upload/example-10-defaultValue.js
@@ -33,7 +33,7 @@ export default function() {
           <FontAwesome name="upload" /> Upload file
         </Button>
       </Upload>
-
+      <br />
       <Upload.Image
         action="//jsonplaceholder.typicode.com/posts"
         accept="image/*"

--- a/site/pages/components/Upload/example-11-dragger.js
+++ b/site/pages/components/Upload/example-11-dragger.js
@@ -5,8 +5,10 @@
  *    -- set drop to Drag files to upload.
  */
 import React from 'react'
-import { Upload, Button } from 'shineout'
+import { Upload } from 'shineout'
 import FontAwesome from '../Icon/FontAwesome'
+
+const placholderStyle = { background: '#fafafa', textAlign: 'center', width: '100%', padding: 20 }
 
 function DraggerImage() {
   return (
@@ -20,11 +22,11 @@ function DraggerImage() {
       onStart={f => console.log(f)}
       width={250}
       drop
+      disabled
     >
-      <div style={{ textAlign: 'center', width: '100%', padding: 20 }}>
+      <div style={placholderStyle}>
         <FontAwesome style={{ color: '#409dfd', fontSize: 20 }} name="image" />
-        <br />
-        Click or Drag image to upload
+        <p>Click or Drag image to upload</p>
       </div>
     </Upload.Image>
   )
@@ -38,13 +40,14 @@ function DraggerFile() {
       name="file"
       onSuccess={(res, file) => file.name}
       limit={3}
-      style={{ width: 300 }}
+      style={{ width: 400 }}
       drop
+      disabled
     >
-      <Button>
-        <FontAwesome name="file" />
-        &nbsp; Drop file to upload
-      </Button>
+      <div style={placholderStyle}>
+        <FontAwesome style={{ color: '#409dfd', fontSize: 28 }} name="archive" />
+        <p style={{ marginTop: 14 }}>Click or drag file to this area to upload</p>
+      </div>
     </Upload>
   )
 }

--- a/src/Cascader/index.d.ts
+++ b/src/Cascader/index.d.ts
@@ -144,7 +144,7 @@ export interface CascaderProps<Item, Value> extends StandardProps, FormItemStand
    * 
    * default: none
    */
-  singleRemove: boolean;
+  singleRemove?: boolean;
 
   /**
    * render unmatch value

--- a/src/Upload/Upload.js
+++ b/src/Upload/Upload.js
@@ -377,7 +377,7 @@ class Upload extends PureComponent {
         onDrop={this.handleFileDrop}
         multiple={multiple || limit > 1}
       >
-        <span className={uploadClass('handle')} onClick={this.handleAddClick}>
+        <span className={uploadClass('handle', disabled && 'disabled')} onClick={this.handleAddClick}>
           <Provider value={dragProps}>{children}</Provider>
           <FileInput
             webkitdirectory={webkitdirectory}
@@ -410,8 +410,9 @@ class Upload extends PureComponent {
       removeConfirm,
     } = this.props
     const { files, recycle } = this.state
+    const fileDrop = drop && !imageStyle
     const className = classnames(
-      uploadClass('_', disabled && 'disabled', showUploadList === false && 'hide-list'),
+      uploadClass('_', disabled && 'disabled', showUploadList === false && 'hide-list', fileDrop && 'file-drop'),
       this.props.className
     )
     const FileComponent = imageStyle ? ImageFile : File

--- a/src/styles/upload.less
+++ b/src/styles/upload.less
@@ -107,6 +107,28 @@
     }
   }
 
+  &.@{upload-prefix}-file-drop {
+    .@{upload-prefix}-drop {
+      .@{upload-prefix}-handle {
+        border-color: @colors-primary;
+      }
+    }
+    .@{upload-prefix}-handle {
+      position: relative;
+      width: 100%;
+      border: dashed 1px @upload-image-border;
+      transition: border-color .2s;
+      &:not(.@{upload-prefix}-disabled) {
+        &:hover {
+          border-color: @colors-primary;
+        }
+      }
+      &.@{upload-prefix}-disabled:hover {
+        cursor: not-allowed;
+      }
+    }
+  }
+
   &-view-value&-view-active {
     background: @dropdown-link-hover-bg;
     .@{upload-prefix}-delete svg {

--- a/test/src/Upload/__snapshots__/example.spec.js.snap
+++ b/test/src/Upload/__snapshots__/example.spec.js.snap
@@ -191,6 +191,7 @@ exports[`Snapshot test: Upload[site/pages/components/Upload/example-10-defaultVa
       </a>
     </div>
   </div>
+  <br />
   <div>
     <div>
       <a>
@@ -229,8 +230,9 @@ exports[`Snapshot test: Upload[site/pages/components/Upload/example-11-dragger.j
         <div>
           <div>
             <i />
-            <br />
-            Click or Drag image to upload
+            <p>
+              Click or Drag image to upload
+            </p>
           </div>
         </div>
         <input />
@@ -241,12 +243,12 @@ exports[`Snapshot test: Upload[site/pages/components/Upload/example-11-dragger.j
   <div>
     <span>
       <span>
-        <button>
+        <div>
           <i />
-          <span>
-              Drop file to upload
-          </span>
-        </button>
+          <p>
+            Click or drag file to this area to upload
+          </p>
+        </div>
         <input />
       </span>
     </span>


### PR DESCRIPTION
- 需求描述：Upload 拖拽上传文件时，宽度无法设置为 100%。原因是因为Upload结构中限制了宽度。
- 解决方案：优化 Upload 中 handler 层样式，使之宽度能够填满整行