### PR TITLE
fix: pagination more text erro in table

### DIFF
--- a/src/styles/pagination.less
+++ b/src/styles/pagination.less
@@ -113,6 +113,7 @@
 
     &:before {
       position: absolute;
+      white-space: nowrap;
       top: 50%;
       left: 50%;
       content: '\2022\2022\2022';


### PR DESCRIPTION
- 问题描述：Pagination small 在 Table 展开行中，更多按钮(...)文字会换行展示
- 原因：talbe的样式设置了文字内容自动换行
- 解决：覆盖pagination自身文字样式