### PR TITLE
fix: datepicker pick-width add quickselect

### DIFF
--- a/src/DatePicker/Container.js
+++ b/src/DatePicker/Container.js
@@ -204,6 +204,8 @@ class Container extends PureComponent {
   }
 
   handleToggle(focus, e) {
+    const { quickSelect } = this.props
+    const hasQuickColumn = Array.isArray(quickSelect) && quickSelect.length > 0
     if (this.props.disabled === true) return
     if (focus === this.state.focus) return
     if (e && focus && getParent(e.target, this.pickerContainer)) return
@@ -217,7 +219,7 @@ class Container extends PureComponent {
           const rect = this.element.getBoundingClientRect()
           const windowHeight = docSize.height
           const windowWidth = docSize.width
-          const pickerWidth = this.props.range ? 540 : 270
+          const pickerWidth = this.props.range ? 540 : 270 + (hasQuickColumn ? 120 : 0)
           if (!this.props.position) {
             if (rect.bottom + 300 > windowHeight) {
               if (rect.left + pickerWidth > windowWidth) state.position = 'right-top'

--- a/src/styles/datepicker.less
+++ b/src/styles/datepicker.less
@@ -506,6 +506,9 @@
     min-width: 80px;
     border-right: 1px solid @divider-color;
     &-item {
+      max-width: 120px;
+      text-overflow: ellipsis;
+      overflow: hidden;
       white-space: nowrap;
       padding: 4px 12px;
       cursor: pointer;


### PR DESCRIPTION
- 问题描述：DatePicker 快速选择模式下，从视窗右侧弹出时position计算出错
- 问题原因：在计算pickerview width的时候，没有考虑到快速选择列