### PR TITLE
feat: modal add forceMask

### DIFF
--- a/site/pages/components/Modal/cn.md
+++ b/site/pages/components/Modal/cn.md
@@ -36,6 +36,7 @@
 | events | object | 无 | 外层元素所接受的事件列表，可用于在 createPortal 场景中阻止冒泡 | |
 | fullScreen | boolean | false | 是否全屏展示 | |
 | top | number \| string | 10vh | 距离顶部距离 | |
+| forceMask | boolean | false | 是否强制设置遮罩透明度（多层Modal中，除第一层外的其他Modal遮罩透明度会被调整为0.01） | |
 
 ### ModalMethods
 

--- a/site/pages/components/Modal/en.md
+++ b/site/pages/components/Modal/en.md
@@ -36,6 +36,7 @@ You can use Modal to display secondary content or actions without jumping to the
 | events | object | none | modal events list, use stopPropagation at createPortal | |
 | fullScreen | boolean | false | display modal with full screen | |
 | top | number \| string | 10vh | distance from top | |
+| forceMask | boolean | false | Whether to force the mask transparency (in multi-layer Modal, the transparency of other Modal masks except the first layer will be adjusted to 0.01) | |
 
 ### ModalMethods
 

--- a/src/Modal/events.js
+++ b/src/Modal/events.js
@@ -84,7 +84,7 @@ export function createDiv(props) {
 
 // eslint-disable-next-line
 export function open(props, isPortal) {
-  const { content, onClose, zIndex, ...otherProps } = props
+  const { content, onClose, zIndex, forceMask, ...otherProps } = props
   const div = createDiv(props)
   div.style.display = 'block'
   const parsed = parseInt(zIndex, 10)
@@ -101,7 +101,7 @@ export function open(props, isPortal) {
   }
 
   const opacityDefault = props.maskOpacity === undefined ? 0.25 : props.maskOpacity
-  const maskOpacity = isMask(props.id) ? opacityDefault : 0.01
+  const maskOpacity = isMask(props.id) || forceMask ? opacityDefault : 0.01
   div.style.background = props.maskBackground || `rgba(0,0,0,${maskOpacity})`
 
   containers[props.id].visible = true

--- a/src/Modal/index.d.ts
+++ b/src/Modal/index.d.ts
@@ -7,6 +7,15 @@ type ReactNode = React.ReactNode;
 export interface ModalProps extends StandardProps {
 
   /**
+   * Whether to force the mask transparency (in multi-layer Modal, the transparency of other Modal masks except the first layer will be adjusted to 0.01)	
+   * 
+   * 是否强制设置遮罩透明度（多层Modal中，除第一层外的其他Modal遮罩透明度会被调整为0.01）
+   * 
+   * default: false
+   */
+  forceMask?: boolean;
+
+  /**
    * Distance from top
    * 
    * 模态框距离顶部距离


### PR DESCRIPTION
- 需求描述：多层modal自动会将一层后面的modal遮罩透明度设置为0.01，如果遇到后面的modal高度低于前一层modal，美观度方面会下降。
- 问题解决：提供forceMask属性，用于关闭此特性