### PR TITLE
feat: popover add z-index

### DIFF
--- a/site/pages/components/Popover/cn.md
+++ b/site/pages/components/Popover/cn.md
@@ -22,12 +22,13 @@
 | style | object | 无 | 最外层扩展样式 |
 | trigger | 'click' \| 'hover' | 'hover' | 触发方式 |
 | type | 'success' \| 'info' \| 'warning' \| 'danger' | 无 | 类型 |
-| content | (close: () => void) => void \| ReactNode | | 旧接口，如果content为空，父组件作为触发元素 | 
+| content | (close: () => void) => void \| ReactNode | 无 | 旧接口，如果content为空，父组件作为触发元素 | 
 | priorityDirection | string | 'vertical' | 弹出位置优先级, 默认为左右优先, 只在未设置 position 时生效, 可选值\['vertical', 'horizontal'] |
 | getPopupContainer | () => HTMLElement | 无 | 自定义Popover容器，覆盖默认渲染在body下的行为, () => DOMElement |
 | scrollDismiss | () => HTMLElement \| boolean | false | 滚动来关闭气泡框，如果需要指定滚动元素，则通过函数返回 |
 | showArrow | boolean | true | 是否显示箭头 |
-| zIndex | number | 1060 | popover 层级 |
+| zIndex | number | 1060 | popover 层级 |  
+| clickToCancelDelay | boolean | false | 在mouseEnterDelay内点击元素后取消弹出 |
 
 ### Popover.Confirm
 | 属性 | 类型 | 默认值 | 说明 |

--- a/site/pages/components/Popover/cn.md
+++ b/site/pages/components/Popover/cn.md
@@ -27,6 +27,7 @@
 | getPopupContainer | () => HTMLElement | 无 | 自定义Popover容器，覆盖默认渲染在body下的行为, () => DOMElement |
 | scrollDismiss | () => HTMLElement \| boolean | false | 滚动来关闭气泡框，如果需要指定滚动元素，则通过函数返回 |
 | showArrow | boolean | true | 是否显示箭头 |
+| zIndex | number | 1060 | popover 层级 |
 
 ### Popover.Confirm
 | 属性 | 类型 | 默认值 | 说明 |

--- a/site/pages/components/Popover/en.md
+++ b/site/pages/components/Popover/en.md
@@ -22,13 +22,14 @@
 | style | object | - | The pop-up container style |
 | trigger | 'click' \| 'hover' | 'hover' | type of show |
 | type | 'success' \| 'info' \| 'warning' \| 'danger' | none | type of popover |
-| content | (close: () => void) => void \| ReactNode | | Old API, out of date. | 
+| content | (close: () => void) => void \| ReactNode | - | Old API, out of date. | 
 | priorityDirection | string | 'vertical' | Popup location priority, default is left and right priority, only valid when position is not set, Options: \['vertical', 'horizontal'] |
 | getPopupContainer | () => HTMLElement | none | Custom Popover container, override the default behavior which is rendering under the body, () => DOMElement |
 | scrollDismiss |  () => HTMLElement \| boolean| false | scroll to dismiss, return el to order scroller |
 | showArrow | boolean | true | show arrow |
 | okType | string | *primary* |  ok button's type, same with Button type |
 | zIndex | number | 1060 | z-index of popover |
+| clickToCancelDelay | boolean | false | Cancel the popup after clicking the element in mouseEnterDelay |
 
 ### Popover.Confirm
 

--- a/site/pages/components/Popover/en.md
+++ b/site/pages/components/Popover/en.md
@@ -28,6 +28,7 @@
 | scrollDismiss |  () => HTMLElement \| boolean| false | scroll to dismiss, return el to order scroller |
 | showArrow | boolean | true | show arrow |
 | okType | string | *primary* |  ok button's type, same with Button type |
+| zIndex | number | 1060 | z-index of popover |
 
 ### Popover.Confirm
 

--- a/src/Popover/Panel.js
+++ b/src/Popover/Panel.js
@@ -45,12 +45,13 @@ class Panel extends Component {
   componentDidMount() {
     super.componentDidMount()
 
-    const { bindChain } = this.props
+    const { bindChain, zIndex } = this.props
     if (bindChain) bindChain(this.id)
 
     this.parentElement = this.placeholder.parentElement
     this.bindEvents()
     this.container = this.getContainer()
+    this.element.style.zIndex = zIndex
     this.container.appendChild(this.element)
 
     if (this.props.visible) this.forceUpdate()
@@ -65,6 +66,9 @@ class Panel extends Component {
   componentDidUpdate(prevProps) {
     if (this.props.trigger !== prevProps.trigger) {
       this.bindEvents()
+    }
+    if (this.props.zIndex !== prevProps.zIndex && this.element) {
+      this.element.style.zIndex = this.props.zIndex
     }
   }
 
@@ -269,6 +273,7 @@ Panel.propTypes = {
   scrollDismiss: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
   showArrow: PropTypes.bool,
   bindChain: PropTypes.func,
+  zIndex: PropTypes.number,
 }
 
 Panel.defaultProps = {

--- a/src/Popover/Panel.js
+++ b/src/Popover/Panel.js
@@ -38,6 +38,7 @@ class Panel extends Component {
     this.handleHide = this.handleHide.bind(this)
     this.setShow = this.setShow.bind(this)
     this.bindChain = this.bindChain.bind(this)
+    this.handleCancel = this.handleCancel.bind(this)
 
     this.element = document.createElement('div')
   }
@@ -157,15 +158,19 @@ class Panel extends Component {
   }
 
   bindEvents() {
-    const { trigger } = this.props
+    const { trigger, clickToCancelDelay, mouseEnterDelay } = this.props
     if (trigger === 'hover') {
       this.parentElement.addEventListener('mouseenter', this.handleShow)
       this.parentElement.addEventListener('mouseleave', this.handleHide)
       this.element.addEventListener('mouseenter', this.handleShow)
       this.element.addEventListener('mouseleave', this.handleHide)
       this.parentElement.removeEventListener('click', this.handleShow)
+      if (clickToCancelDelay && mouseEnterDelay > 0) {
+        this.parentElement.addEventListener('click', this.handleCancel)
+      }
     } else {
       this.parentElement.addEventListener('click', this.handleShow)
+      this.parentElement.removeEventListener('click', this.handleCancel)
       this.parentElement.removeEventListener('mouseenter', this.handleShow)
       this.parentElement.removeEventListener('mouseleave', this.handleHide)
       this.element.removeEventListener('mouseenter', this.handleShow)
@@ -208,6 +213,10 @@ class Panel extends Component {
   isChildren(el) {
     for (let i = 0; i < this.chain.length; i++) if (getParent(el, `.${this.chain[i]}`)) return true
     return false
+  }
+
+  handleCancel() {
+    if (this.delayTimeout) clearTimeout(this.delayTimeout)
   }
 
   handleHide(e) {
@@ -274,6 +283,7 @@ Panel.propTypes = {
   showArrow: PropTypes.bool,
   bindChain: PropTypes.func,
   zIndex: PropTypes.number,
+  clickToCancelDelay: PropTypes.bool,
 }
 
 Panel.defaultProps = {

--- a/src/Popover/index.d.ts
+++ b/src/Popover/index.d.ts
@@ -5,6 +5,15 @@ import { StandardProps }  from '../@types/common'
 type ReactNode = React.ReactNode
 
 export interface PopoverProps extends StandardProps {
+
+  /**
+   * Cancel the popup after clicking the element in mouseEnterDelay
+   * 
+   * 在 mouseEnterDelay 内点击元素后取消弹出	
+   * 
+   * default: false
+   */
+  clickToCancelDelay?: boolean;
   
   /**
    * z-index of popover

--- a/src/Popover/index.d.ts
+++ b/src/Popover/index.d.ts
@@ -5,6 +5,15 @@ import { StandardProps }  from '../@types/common'
 type ReactNode = React.ReactNode
 
 export interface PopoverProps extends StandardProps {
+  
+  /**
+   * z-index of popover
+   * 
+   * Popover 层级
+   * 
+   * default: 1060
+   */
+  zIndex?: number;
 
   /**
    * Pop-up background-color(with arrows)


### PR DESCRIPTION
- popover新增clickToCancelDelay属性，用于在在 mouseEnterDelay 内点击元素后取消弹出
- popover新增zIndex属性，用于通过props来控制popover的z-index