### PR TITLE
Fix/select/renderplaceholder

### DIFF
--- a/src/Select/Result.js
+++ b/src/Select/Result.js
@@ -181,10 +181,10 @@ class Result extends PureComponent {
   }
 
   renderPlaceholder() {
-    const { focus, onFilter } = this.props
+    const { focus, onFilter, filterText } = this.props
 
     if (focus && onFilter) {
-      return this.renderInput()
+      return this.renderInput(filterText)
     }
 
     return (


### PR DESCRIPTION
bug描述： select多列选项并有筛选方法情形下->输入text->全选->取消全选 ->会把输入的text也清空，导致不能通过删除text恢复全部选项
原因： 当数据为空的时候触发renderPlaceholder 中的 renderInput 传入的text 为空 
解决办法： renderInput 中的text 传入 filterText