### PR TITLE
fix: expanded-table data change

### DIFF
--- a/src/Table/Tr.js
+++ b/src/Table/Tr.js
@@ -26,7 +26,7 @@ const isExpandableElement = el => {
 class Tr extends Component {
   constructor(props) {
     super(props)
-
+    this.manualExpand = false
     this.bindElement = this.bindElement.bind(this)
     this.handleRowClick = this.handleRowClick.bind(this)
     this.setRowHeight = this.setRowHeight.bind(this)
@@ -46,7 +46,7 @@ class Tr extends Component {
         setTranslate(td, `-${offsetRight}px`, '0')
       })
     }
-
+    this.manualExpand = true
     this.setRowHeight()
   }
 
@@ -78,7 +78,7 @@ class Tr extends Component {
 
   setExpandHeight(height) {
     this.expandHeight = height
-    this.setRowHeight(true)
+    this.setRowHeight(this.manualExpand)
   }
 
   getRowClickAttr() {


### PR DESCRIPTION
- 问题描述：Table 默认 expaned 所有行的时候，此时筛选数据（将数据减少），会导致滚动条停留和视图停留在原来的位置，空白。
- 问题原因：在resetHeight中，如果是因为展开行造成的位置变化则会忽略，但是没有处理默认展开行的情况。
- 问题解决：在tr中添加默认展开行和手动展开行的处理逻辑