### PR TITLE
Fix datetimepicker

### DIFF
--- a/src/DatePicker/Day.js
+++ b/src/DatePicker/Day.js
@@ -60,8 +60,9 @@ class Day extends PureComponent {
   }
 
   handleDayClick(date, sync) {
-    const { type, allowSingle, rangeDate, min, max, index } = this.props
-    const current = this.formatWithDefaultTime(sync)
+    const { type, allowSingle, rangeDate, min, max, index, value } = this.props
+    // if has value use value time
+    const current = value || this.formatWithDefaultTime(sync)
     const onChange = typeof sync === 'number' ? this.props.onChangeSync.bind(this.props, sync) : this.props.onChange
     if (type === 'week') {
       // if (date.getDay() === 0) {


### PR DESCRIPTION
问题：当选择日期的时候 时分秒会被重置
解决：如果有日期有值 修改日期的时候 时分秒保留