### PR TITLE
修复tree 拖动后错位问题 bug

### DIFF
--- a/src/Tree/Node.js
+++ b/src/Tree/Node.js
@@ -106,9 +106,9 @@ class Node extends PureComponent {
   handleDragOver(e) {
     if (!isDragging) return
 
-    const { dragHoverExpand, datum, dragSibling, index } = this.props
+    const { dragHoverExpand, datum, dragSibling } = this.props
     const startId = placeElement.getAttribute('data-start')
-    const startIndex = parseInt(placeElement.getAttribute('data-start-index'), 10)
+    // const startIndex = parseInt(placeElement.getAttribute('data-start-index'), 10)
     const current = datum.getPath(startId)
     const target = datum.getPath(this.props.id)
 
@@ -142,7 +142,9 @@ class Node extends PureComponent {
       position += 1
       hover.parentNode.insertBefore(placeElement, hover.nextElementSibling)
     }
-    position += startIndex <= index ? -1 : 0
+    // if (position !== -1 && currentPathStr === targetPathStr && startIndex <= index) {
+    //   position -= 1
+    // }
     placeElement.setAttribute('data-target', this.props.id)
     placeElement.setAttribute('data-position', position)
   }

--- a/src/Tree/Tree.js
+++ b/src/Tree/Tree.js
@@ -134,6 +134,7 @@ class Tree extends PureComponent {
       let node = draft
       let temp
       let removeNode
+      let offset = 0
       current.indexPath.forEach((p, i) => {
         if (i < current.indexPath.length - 1) {
           node = node[p][childrenKey]
@@ -151,19 +152,22 @@ class Tree extends PureComponent {
         } else if (tnode === temp) {
           // same parent
           removeNode()
+          if (current.index <= target.index) {
+            offset = -1
+          }
           removeNode = () => {}
         }
       })
 
       if (position === -1) {
-        tnode = tnode[target.index]
+        tnode = tnode[target.index + offset]
         if (!Array.isArray(tnode[childrenKey])) tnode[childrenKey] = []
         tnode[childrenKey].push(node)
         position = tnode[childrenKey].length - 1
         const update = this.nodes.get(targetId)
         if (update) update('expanded', true)
       } else {
-        tnode.splice(position, 0, node)
+        tnode.splice(position + offset, 0, node)
         targetId = target.path[target.path.length - 1]
       }
 


### PR DESCRIPTION
1. 同级别 A拖入B 当A在B的上方时候无效
2. 先将A拖入B，再把A原地拖动A会变成和B同级(偶现)
