### PR TITLE
fix: treeSelect will over doc when onExpand

### DIFF
--- a/src/AnimationList/AbsoluteList.js
+++ b/src/AnimationList/AbsoluteList.js
@@ -38,6 +38,9 @@ export default function(List) {
       if (!root) initRoot()
       this.element = document.createElement('div')
       root.appendChild(this.element)
+      if (props.getResetPosition) {
+        props.getResetPosition(this.resetPosition.bind(this))
+      }
     }
 
     componentDidUpdate(prevProps) {
@@ -133,9 +136,9 @@ export default function(List) {
       return { focus, style }
     }
 
-    resetPosition() {
+    resetPosition(clean) {
       const { focus, parentElement } = this.props
-      if (!this.el || !focus || this.ajustdoc) return
+      if (!this.el || !focus || (this.ajustdoc && !clean)) return
       const pos = this.el.getBoundingClientRect()
       let { left } = pos
       if (parentElement) {
@@ -167,6 +170,7 @@ export default function(List) {
         scrollElement,
         style = {},
         zIndex,
+        getResetPosition,
         ...props
       } = this.props
       const parsed = parseInt(zIndex, 10)
@@ -193,6 +197,8 @@ export default function(List) {
         scrollElement,
         autoClass,
         zIndex,
+        // do not need the getUpdate
+        getResetPosition,
         // do not need the value
         value,
         ...props
@@ -228,6 +234,7 @@ export default function(List) {
     style: PropTypes.object,
     autoClass: PropTypes.string,
     value: PropTypes.any,
+    getResetPosition: PropTypes.func,
   }
 
   return compose(

--- a/src/TreeSelect/TreeSelect.js
+++ b/src/TreeSelect/TreeSelect.js
@@ -244,10 +244,27 @@ export default class TreeSelect extends PureComponent {
       data.length === 0 ? (
         <span className={treeSelectClass('option')}>{this.getText('noData')}</span>
       ) : (
-        <Tree className={treeSelectClass(!multiple && 'single')} {...props} dataUpdate={false} />
+        <Tree
+          className={treeSelectClass(!multiple && 'single')}
+          {...props}
+          dataUpdate={false}
+          onExpand={(...args) => {
+            if (this.resetAbsoluteListPosition) {
+              setTimeout(() => {
+                this.resetAbsoluteListPosition(true)
+              })
+            }
+            if (this.props.onExpand) {
+              this.props.onExpand(...args)
+            }
+          }}
+        />
       )
     return (
       <OptionList
+        getResetPosition={update => {
+          this.resetAbsoluteListPosition = update
+        }}
         absolute={absolute}
         rootClass={treeSelectClass(position, isRTL() && 'rtl')}
         parentElement={this.element}


### PR DESCRIPTION
当节点展开列表可能会超出容器 需要调用resetPosition