### PR TITLE
fix: treeSelect will over doc when onExpand

### DIFF
--- a/src/AnimationList/AbsoluteList.js
+++ b/src/AnimationList/AbsoluteList.js
@@ -38,6 +38,9 @@ export default function(List) {
       if (!root) initRoot()
       this.element = document.createElement('div')
       root.appendChild(this.element)
+      if (props.getResetPosition) {
+        props.getResetPosition(this.resetPosition.bind(this))
+      }
     }
 
     componentDidUpdate(prevProps) {
@@ -133,9 +136,9 @@ export default function(List) {
       return { focus, style }
     }
 
-    resetPosition() {
+    resetPosition(clean) {
       const { focus, parentElement } = this.props
-      if (!this.el || !focus || this.ajustdoc) return
+      if (!this.el || !focus || (this.ajustdoc && !clean)) return
       const pos = this.el.getBoundingClientRect()
       let { left } = pos
       if (parentElement) {
@@ -167,6 +170,7 @@ export default function(List) {
         scrollElement,
         style = {},
         zIndex,
+        getResetPosition,
         ...props
       } = this.props
       const parsed = parseInt(zIndex, 10)
@@ -193,6 +197,8 @@ export default function(List) {
         scrollElement,
         autoClass,
         zIndex,
+        // do not need the getUpdate
+        getResetPosition,
         // do not need the value
         value,
         ...props
@@ -228,6 +234,7 @@ export default function(List) {
     style: PropTypes.object,
     autoClass: PropTypes.string,
     value: PropTypes.any,
+    getResetPosition: PropTypes.func,
   }
 
   return compose(

--- a/src/TreeSelect/TreeSelect.js
+++ b/src/TreeSelect/TreeSelect.js
@@ -31,7 +31,8 @@ export default class TreeSelect extends PureComponent {
     }
 
     this.treeSelectId = `treeSelect_${getUidStr()}`
-
+    this.onExpandHandler = this.onExpandHandler.bind(this)
+    this.getResetPosition = this.getResetPosition.bind(this)
     this.setInputReset = this.setInputReset.bind(this)
     this.renderActive = this.renderActive.bind(this)
     this.handleChange = this.handleChange.bind(this)
@@ -65,11 +66,15 @@ export default class TreeSelect extends PureComponent {
     this.clearClickAway()
   }
 
-  getValue() {
-    const { datum, multiple } = this.props
-    const value = datum.getValue()
-    if (multiple) return value
-    return value.length ? value[0] : ''
+  onExpandHandler(...args) {
+    if (this.resetAbsoluteListPosition) {
+      setTimeout(() => {
+        this.resetAbsoluteListPosition(true)
+      })
+    }
+    if (this.props.onExpand) {
+      this.props.onExpand(...args)
+    }
   }
 
   getText(key) {
@@ -78,6 +83,17 @@ export default class TreeSelect extends PureComponent {
 
   setInputReset(fn) {
     this.inputReset = fn
+  }
+
+  getValue() {
+    const { datum, multiple } = this.props
+    const value = datum.getValue()
+    if (multiple) return value
+    return value.length ? value[0] : ''
+  }
+
+  getResetPosition(update) {
+    this.resetAbsoluteListPosition = update
   }
 
   bindElement(el) {
@@ -244,10 +260,16 @@ export default class TreeSelect extends PureComponent {
       data.length === 0 ? (
         <span className={treeSelectClass('option')}>{this.getText('noData')}</span>
       ) : (
-        <Tree className={treeSelectClass(!multiple && 'single')} {...props} dataUpdate={false} />
+        <Tree
+          className={treeSelectClass(!multiple && 'single')}
+          {...props}
+          dataUpdate={false}
+          onExpand={this.onExpandHandler}
+        />
       )
     return (
       <OptionList
+        getResetPosition={this.getResetPosition}
         absolute={absolute}
         rootClass={treeSelectClass(position, isRTL() && 'rtl')}
         parentElement={this.element}


### PR DESCRIPTION
当treeSelect 节点展开的时候列表位置可能会溢出文档，需要新计算