### PR TITLE
Feat/table/adjustscroll

### DIFF
--- a/src/Scroll/Scroll.js
+++ b/src/Scroll/Scroll.js
@@ -178,21 +178,21 @@ class Scroll extends PureComponent {
     // }
   }
 
-  handleScroll(x, y, pixelX, pixelY) {
+  handleScroll(x, y, pixelX, pixelY, { drag } = {}) {
     const { scrollWidth } = this.props
     const { width, height } = this.getWheelRect()
     const max = Math.round((1 - width / scrollWidth) * scrollWidth)
     if (this.props.onScroll) {
-      this.props.onScroll(x, y, max, this.inner, width, height, pixelX, pixelY)
+      this.props.onScroll(x, y, max, this.inner, width, height, pixelX, pixelY, drag)
     }
   }
 
   handleScrollX(left) {
-    this.handleScroll(left, this.props.top, undefined, 0)
+    this.handleScroll(left, this.props.top, undefined, 0, { drag: true })
   }
 
   handleScrollY(top) {
-    this.handleScroll(this.props.left, top)
+    this.handleScroll(this.props.left, top, undefined, undefined, { drag: true })
   }
 
   handleTouchStart(e) {

--- a/src/Table/SeperateTable.js
+++ b/src/Table/SeperateTable.js
@@ -172,7 +172,7 @@ class SeperateTable extends PureComponent {
 
   ajustBottom(dataChange) {
     const reachBottom = this.lastScrollArgs[1] === 1
-    const drag = this.lastScrollArgs[7] === undefined
+    const drag = this.lastScrollArgs[8]
     if (!dataChange && reachBottom && drag) {
       setTimeout(() => {
         this.handleScroll(...this.lastScrollArgs)


### PR DESCRIPTION
问题描述：table 在滚动到底部 onScroll 的时候异步请求数据， 当resize 的时候会进入死循环
问题原因：代码中seprateTable didupdate的时候调用了 ajustBottom 方法 触发onScroll 然后又触发didupdate 导致死循环
解决办法：ajustBottom方法是解决drag 拖拽后数据渲染的问题的 可以在判断如果不是拖拽 就跳过。