### PR TITLE
fix datepicker 双击结束时间日期不对

### DIFF
--- a/site/pages/components/DatePicker/example-09-range-date.js
+++ b/site/pages/components/DatePicker/example-09-range-date.js
@@ -58,6 +58,7 @@ export default function() {
       <DatePicker
         range
         type="datetime"
+        defaultTime={['00:00:00', '23:59:59']}
         style={style}
         onChange={d => console.log(d)}
         placeholder={['Start datetime', 'End datetime']}

--- a/src/DatePicker/Day.js
+++ b/src/DatePicker/Day.js
@@ -62,7 +62,8 @@ class Day extends PureComponent {
   handleDayClick(date, sync) {
     const { type, allowSingle, rangeDate, min, max, index, value } = this.props
     // if has value use value time
-    const current = value || this.formatWithDefaultTime(sync)
+
+    const current = (index === sync && value) || this.formatWithDefaultTime(sync)
     const onChange = typeof sync === 'number' ? this.props.onChangeSync.bind(this.props, sync) : this.props.onChange
     if (type === 'week') {
       // if (date.getDay() === 0) {


### PR DESCRIPTION
问题描述： datepicker  组件范围选择，双击选择的时候defaultTime 失效
问题原因：双击的里面调用的click 方法 里面判断了如果value 有值 时分秒保持不变。
解决原因： 区分双击的时候还是使用defaultTime中的时间