### PR TITLE
seprate table 当拖动列后会导致高度计算错误

### DIFF
--- a/src/Table/SeperateTable.js
+++ b/src/Table/SeperateTable.js
@@ -505,6 +505,7 @@ class SeperateTable extends PureComponent {
               resize={resize}
               colgroup={colgroup}
               onScrollTop={this.scrollToTop}
+              columnResizable={columnResizable}
             />
           </table>
         </div>

--- a/src/Table/resizable.js
+++ b/src/Table/resizable.js
@@ -21,16 +21,18 @@ export default Table =>
 
     componentDidUpdate(prevProps) {
       const prevColumns = prevProps.columns
-      const { columns } = this.props
+      const { columns, onColumnResize } = this.props
       if (prevColumns !== columns) {
         if (prevColumns.length !== columns.length) {
           this.setState({ columns })
         } else {
-          const widthed = immer(columns, draft => {
-            draft.forEach((column, index) => {
-              column.width = this.state.columns[index].width
-            })
-          })
+          const widthed = onColumnResize
+            ? columns
+            : immer(columns, draft => {
+                draft.forEach((column, index) => {
+                  column.width = this.state.columns[index].width
+                })
+              })
           this.setState({ columns: widthed })
         }
       }


### PR DESCRIPTION
1.直接使用table 拖动后下方会有留白
2.结合TableSorter 使用后下方会有列被隐藏
原因1： columnResizeable 没有向下透传到tr 导致didupdate 判断错误
原因2： 当传递了onColumnResize当时候列当宽度是自己维护当 此时当width 在didiupdate 以后每次都会被第一次加载当column 给覆盖 导致tr 没有更新。