### PR TITLE
fix Progress组件circle模式下size与实际渲染的尺寸不符

### DIFF
--- a/src/Progress/Circle.js
+++ b/src/Progress/Circle.js
@@ -8,7 +8,7 @@ function Circle(props) {
   const { children, strokeWidth, type, color, size, value, background, strokeLinecap } = props
   const className = classnames(progressClass('circle', type), props.className)
 
-  const r = 100 - Math.ceil(((strokeWidth * 2) / size) * 100)
+  const r = 100 - Math.ceil((strokeWidth / size) * 100)
 
   const p = Math.PI * 2 * r
   const dasharray = [p * (value / 100), p * (1 - value / 100)]


### PR DESCRIPTION
原因： svg circle 的盒模型是属于contentBox 当有stokenWidth的时候要减去 r 要减去stokenWidth. 计算半径的时候多减去了一个stokenWidth