### PR TITLE
fix:  当 table 有 treeCheckAll属性， 选择行的时候会缓存data， 导致数据改变后 选择行的数据不对，

### DIFF
--- a/src/Datum/List.js
+++ b/src/Datum/List.js
@@ -26,6 +26,11 @@ export default class {
     return this.$values.length
   }
 
+  // should clean $cachedFlatten when data changed
+  cleanDataCache() {
+    this.$cachedFlatten = new Map()
+  }
+
   get values() {
     return this.$values
   }

--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -36,10 +36,13 @@ class Table extends Component {
     this.bindTable = this.bindTable.bind(this)
   }
 
-  componentDidUpdate() {
-    const { datum } = this.props
+  componentDidUpdate(preProps) {
+    const { datum, treeCheckAll } = this.props
     datum.dispatch(ROW_HEIGHT_UPDATE_EVENT)
     datum.dispatch(RENDER_COL_GROUP_EVENT)
+    if (treeCheckAll && this.props.data !== preProps.data) {
+      datum.cleanDataCache()
+    }
   }
 
   getRowsInView() {


### PR DESCRIPTION
问题：当 table 有 treeCheckAll属性， 选择行的时候会缓存data， 导致数据改变后 选择行的数据不对， 
原因： 进行了缓存 导致选中的数据为之前的数据
解决办法： 当data 改变后清除缓存
复线地址：https://codesandbox.io/s/table-treecheckall-cache-1kkz3?file=/App.js:723-735