### PR TITLE
fix: tree拖拽后无法选择

### DIFF
--- a/src/Tree/Checkbox.js
+++ b/src/Tree/Checkbox.js
@@ -18,6 +18,16 @@ export default class extends PureComponent {
     props.datum.bind(props.id, this.forceUpdate.bind(this))
   }
 
+  componentDidMount() {
+    super.componentDidMount()
+    // When dragging a node,
+    // it will first trigger the constructor of the new node,
+    // then trigger the willUnmount of the old node,
+    // and finally trigger the didMount of the new node,
+    // the old node will unload the update event, so bind it here again
+    this.props.datum.bind(this.props.id, this.forceUpdate.bind(this))
+  }
+
   componentWillUnmount() {
     super.componentWillUnmount()
     this.props.datum.unbind(this.props.id)


### PR DESCRIPTION
fix: tree拖拽后无法选择 
jira: CYWEB-1936
复线: https://codesandbox.io/s/tree-selectall-after-drag-hm9mv?file=/App.js:0-842
原因：拖动节点时，会先触发新节点的构造函数，然后触发老节点的willUnmount，最后触发新节点的didMount，老节点在willUnmount的时候会卸载update事件，所以这里再次绑定