### PR TITLE
fix: cascader组件diaabled 的时候 so-cascader-item 的样式会覆盖disabled 的 cursor,…

### DIFF
--- a/src/Cascader/styles/cascader.less
+++ b/src/Cascader/styles/cascader.less
@@ -118,8 +118,13 @@
     }
   }
 
-  &-disabled &-result {
+  &-disabled &-result{
     cursor: not-allowed;
+    .so-cascader-item {
+      cursor: not-allowed;
+      background-color: inherit;
+      color: inherit;
+    }
   }
 
   &:not(&-disabled) {


### PR DESCRIPTION
fix: cascader组件diaabled 的时候 so-cascader-item 的样式会覆盖disabled 的 cursor, color, background-color 样式导致没有展示出禁用样式