### PR TITLE
fix: 当数据改变的时候可能导致相同key的tr组件的index发生变化 在tr中setRowHeight中没有对这种情况处理

### DIFF
--- a/src/Table/Tr.js
+++ b/src/Table/Tr.js
@@ -72,8 +72,15 @@ class Tr extends Component {
       datum.subscribe(ROW_HEIGHT_UPDATE_EVENT, this.setRowHeight)
       return
     }
-    if (height === this.lastRowHeight && this.expandHeight === this.lastExpandHeight && !dataUpdated) return
+    if (
+      height === this.lastRowHeight &&
+      this.expandHeight === this.lastExpandHeight &&
+      !dataUpdated &&
+      this.lastIndex === this.props.index
+    )
+      return
     this.lastRowHeight = height
+    this.lastIndex = this.props.index
     this.lastExpandHeight = this.expandHeight
     setRowHeight(height + this.expandHeight, this.props.index, expand)
   }


### PR DESCRIPTION
问题描述： table 数据 在 前面插入新数据后 列表的行高计算错误。
问题原因：table tr 实例的index 发生了变化 但是没有重新保存行高
解决办法：在tr组件setRowHeight的判断中增加判断确保index改变后重新保存行高
复现地址： https://codesandbox.io/s/table-not-setrowheight-j770d?file=/App.js