### PR TITLE
table 滚动到下方的时候 减少数据可能会出现 滚动到没有数据到区域， 需要重新计算滚动条位置

### DIFF
--- a/src/Table/SeperateTable.js
+++ b/src/Table/SeperateTable.js
@@ -235,7 +235,9 @@ class SeperateTable extends PureComponent {
     if (this.lastScrollTop - height >= 1) {
       const index = this.resetIndex()
       this.setState({ currentIndex: index })
-
+      setTimeout(() => {
+        this.handleScroll(...this.lastScrollArgs)
+      })
       if (this.renderByExpand) {
         this.renderByExpand = false
         return


### PR DESCRIPTION
问题描述：  table组件第一页拉到底部，然后切最后一页的时候显示白屏，然后向上滚动出现最后一页数据
问题原因： table 组件的滚动条高度没有更新
解决办法： 判断数据更新后再滚动高度变化的情况下需要重新计算
codesandbox:  https://codesandbox.io/s/tablegun-dong-dao-di-bu-ran-hou-dian-ji-gai-bian-shu-ju-ye-mian-hui-bian-cheng-kong-bai-xb9rw?file=/App.js