### PR TITLE
优化 Menu 样式 暗黑模式下选中的父节点菜单 hover 颜色为白色

### DIFF
--- a/src/Menu/styles/menu.less
+++ b/src/Menu/styles/menu.less
@@ -479,6 +479,9 @@
     &.@{menu-prefix}-inline, &.@{menu-prefix}-horizontal {
       .@{menu-prefix}-in-path.@{menu-prefix}-has-children > a {
         color: @menu-dark-item;
+        &:hover {
+          color: @menu-item-dark-hover-color;
+        }
       }
     }
   }


### PR DESCRIPTION
修复 Menu 暗黑模式下 有二级选择的 一级菜单hover 颜色没有生效