### PR TITLE
修复当Select 同时使用onFilter 和 onCreate的时候 如果filter 输入的值完全等于数据展示的值 会选中创建的数据…

### DIFF
--- a/src/Select/filter.js
+++ b/src/Select/filter.js
@@ -170,7 +170,9 @@ export default Origin =>
       if (innerFilter) newData = data.filter(d => innerFilter(d))
       if (innerData && !hideCreateOption) {
         const newKey = getKey(innerData, other.keygen, innerData)
-        newData = [innerData, ...newData.filter(d => getKey(d, other.keygen, d) !== newKey)]
+        if (!newData.find(d => getKey(d, other.keygen, d) === newKey)) {
+          newData = [innerData, ...newData]
+        }
       }
       return {
         data: newData,


### PR DESCRIPTION
问题表述： 当Select 同时使用onFilter 和 onCreate的时候 如果filter 输入的值完全等于数据展示的值 会选中创建的数据而不是筛选出来的数据
解决办法：修改逻辑onFilter 出来的数据优先级高于onCreate出来的数据
codesandbox: https://codesandbox.io/s/select-filter-oncreate-h5bsl?file=/App.js:80-110