### PR TITLE
优化menu 样式

### DIFF
--- a/site/pages/components/Menu/cn.md
+++ b/site/pages/components/Menu/cn.md
@@ -13,13 +13,15 @@
 | keygen | ((data: object) => string) \| string \| true | 必填 | 生成每一项key的辅助方法<br />为 true 时，以数据项本身作为key，相当于 (d => d)<br />为函数时，使用此函数返回值<br />为string时，使用这个string对应的数据值。如 'id'，相当于 (d => d.id) |
 | active | (data: object) => boolean | null | 验证是否激活,参数为对应的数据对象,返回true则代表该菜单激活 |
 | defaultOpenKeys | string[] | [] | 初始展开的菜单;如果需要设置此值,则需要设置keygen,此值为一个包含key的数组 |
-| openKeys | string[] | [] | 展开的菜单(受控) | 
+| openKeys | string[] | [] | 展开的菜单(受控) |
 | onClick | (data: object) => void | null | 子菜单点击事件,参数为当条数据|
 | style | object | 无 | 最外层扩展样式 |
 | inlineIndent | number | 24 | 每一层缩进宽度 |
-| linkKey | (d: object) => string \| string | 无 | 需要注入子菜单的链接键值 |  
+| linkKey | (d: object) => string \| string | 无 | 需要注入子菜单的链接键值 |
 | onOpenChange | (keys: string[]) => void | 无 | 菜单展开/收起回调 |
 | frontCaret | boolean | null | 前置实心三角展开符 |
+| frontCaretType | 'solid' \| 'hollow' | 'solid' | 前置三角展开符类型，hollow 为空心； solid 为实心  |
+| caretColor | string | 无 | 自定义三角展开符颜色  |
 | theme | 'dark' | 无 | 主题 |
 | looseChildren | boolean | false | 如果 children 有设置则菜单项可展开 |
 | parentSelectable | boolean | false | 父级菜单是否可选中(在点击后是否触发onClick) |

--- a/site/pages/components/Menu/en.md
+++ b/site/pages/components/Menu/en.md
@@ -13,13 +13,15 @@
 | keygen | ((data: object) => string) \| string \| true  | required | Key generator<br />When it is true, the data itself is used as the key equivalent to (d => d)<br />When it is a function, use its return value.<br />When it is a string，ues the value of the string.For example, 'id' is the same thing as (d) => d.id. |
 | active | (data: object) => boolean | null | The item is actived when the active function return true. |
 | defaultOpenKeys | string[] | [] | Initial expanded menu |
-| openKeys | string[] | [] | expended menu | 
+| openKeys | string[] | [] | expended menu |
 | onClick | (data: object) => void | null | The function will be called when the user clicks the menu item. |
 | style | object | - | Container element style |
-| inlineIndent | number | 24 | indent of each level |   
+| inlineIndent | number | 24 | indent of each level |
 | linkKey | (d: object) => string \| string | - |  the key of inject the link value of the submenu |
 | onOpenChange | (keys: string[]) => void | none | menu open change callback |
 | frontCaret | boolean | null | Front solid triangle expansion |
+| frontCaretType | 'solid' \| 'hollow' | 'solid' | front triangle expansion symbol type |
+| caretColor | string | - ｜ triangle expansion color  |
 | theme | 'dark' | none | theme of menu |
 | looseChildren | boolean | false | menu item expandable if has children |
 | parentSelectable | boolean | false | Whether the parent menu is selectable (whether onClick is triggered after clicking)

--- a/src/Menu/Item.js
+++ b/src/Menu/Item.js
@@ -246,7 +246,6 @@ class Item extends PureComponent {
       events.onMouseEnter = this.handleMouseEnter
       events.onMouseLeave = this.handleMouseLeave
     }
-    console.log(frontCaretType, className, frontCaret)
     return (
       <li className={className} {...events} ref={this.bindElement}>
         {this.renderItem(hasChilds, style)}

--- a/src/Menu/Item.js
+++ b/src/Menu/Item.js
@@ -10,7 +10,7 @@ import { isLink } from '../utils/is'
 import { isRTL } from '../config'
 import { getParent } from '../utils/dom/element'
 
-const getBaseIndent = (flag = false) => (flag ? 16 : 20)
+const getBaseIndent = () => 16
 
 const calcIndent = (flag, indent) => {
   if (!flag) return indent
@@ -161,7 +161,7 @@ class Item extends PureComponent {
   }
 
   renderItem(hasChilds = false, style) {
-    const { renderItem, data, index, frontCaret } = this.props
+    const { renderItem, data, index, frontCaret, caretColor } = this.props
     const item = renderItem(data, index)
     const link = this.renderLink(data)
     if (isLink(item)) {
@@ -180,7 +180,7 @@ class Item extends PureComponent {
     if (frontCaret) {
       return (
         <a {...props}>
-          <div className={menuClass('caret', hasChilds && 'has-childs')} />
+          <div style={{ color: caretColor }} className={menuClass('caret', hasChilds && 'has-childs')} />
           {item}
         </a>
       )
@@ -189,7 +189,7 @@ class Item extends PureComponent {
     return (
       <a {...props}>
         {item}
-        <span className={menuClass('expand')} />
+        <span className={menuClass('expand')} style={{ color: caretColor }} />
       </a>
     )
   }
@@ -212,6 +212,7 @@ class Item extends PureComponent {
       frontCaret,
       looseChildren,
       parentSelectable,
+      frontCaretType,
     } = this.props
     const { open, isActive, isHighLight, inPath } = this.state
     const { children: dChildren } = data
@@ -235,7 +236,7 @@ class Item extends PureComponent {
       isUp && 'open-up',
       isHighLight && 'highlight',
       inPath && 'in-path',
-      frontCaret && 'caret-solid',
+      frontCaret && `caret-${frontCaretType}`,
       parentSelectable && 'selectable'
     )
 
@@ -245,7 +246,7 @@ class Item extends PureComponent {
       events.onMouseEnter = this.handleMouseEnter
       events.onMouseLeave = this.handleMouseLeave
     }
-
+    console.log(frontCaretType, className, frontCaret)
     return (
       <li className={className} {...events} ref={this.bindElement}>
         {this.renderItem(hasChilds, style)}
@@ -296,6 +297,8 @@ Item.propTypes = {
   frontCaret: PropTypes.bool,
   looseChildren: PropTypes.bool,
   parentSelectable: PropTypes.bool,
+  frontCaretType: PropTypes.oneOf(['hollow', 'solid']),
+  caretColor: PropTypes.string,
 }
 
 export default consumer(Item)

--- a/src/Menu/List.js
+++ b/src/Menu/List.js
@@ -26,6 +26,8 @@ class List extends PureComponent {
       frontCaret,
       looseChildren,
       parentSelectable,
+      frontCaretType,
+      caretColor,
     } = this.props
 
     const isVertical = mode.indexOf('vertical') === 0
@@ -52,6 +54,8 @@ class List extends PureComponent {
             linkKey={linkKey}
             toggleDuration={toggleDuration}
             frontCaret={frontCaret}
+            frontCaretType={frontCaretType}
+            caretColor={caretColor}
             looseChildren={looseChildren}
             parentSelectable={parentSelectable}
           />
@@ -81,6 +85,8 @@ List.propTypes = {
   frontCaret: PropTypes.bool,
   looseChildren: PropTypes.bool,
   parentSelectable: PropTypes.bool,
+  frontCaretType: PropTypes.oneOf(['hollow', 'solid']),
+  caretColor: PropTypes.string,
 }
 
 export default List

--- a/src/Menu/Root.js
+++ b/src/Menu/Root.js
@@ -287,6 +287,8 @@ class Root extends React.Component {
       frontCaret,
       looseChildren,
       parentSelectable,
+      frontCaretType,
+      caretColor,
     } = this.props
     const isVertical = mode.indexOf('vertical') === 0
     const showScroll = ((style.height || height) && isVertical) || mode === 'horizontal'
@@ -341,6 +343,8 @@ class Root extends React.Component {
               frontCaret={frontCaret}
               looseChildren={looseChildren}
               parentSelectable={parentSelectable}
+              frontCaretType={frontCaretType}
+              caretColor={caretColor}
             />
           </Provider>
         </div>
@@ -365,6 +369,8 @@ Root.propTypes = {
   onOpenChange: PropTypes.func,
   toggleDuration: PropTypes.number,
   frontCaret: PropTypes.bool,
+  frontCaretType: List.propTypes.frontCaretType,
+  caretColor: List.propTypes.caretColor,
 }
 
 Root.defaultProps = {
@@ -379,6 +385,7 @@ Root.defaultProps = {
   defaultOpenKeys: [],
   onClick: () => true,
   toggleDuration: 200,
+  frontCaretType: 'solid',
 }
 
 export default Root

--- a/src/Menu/index.d.ts
+++ b/src/Menu/index.d.ts
@@ -9,18 +9,18 @@ Pick<StructDataStandardProps<Item>, 'renderItem'>
 
   /**
    * parent menu Selectable
-   * 
+   *
    * 父级菜单是否可选中
-   * 
+   *
    * default: false
    */
   parentSelectable?: bool;
-  
+
    /**
     * menu item expandable if has children
-    * 
+    *
     * 如果 children 有设置则菜单项可展开
-    * 
+    *
     * default: false
     */
    looseChildren?: boolean;
@@ -113,6 +113,24 @@ Pick<StructDataStandardProps<Item>, 'renderItem'>
       * default: null
       */
      frontCaret?: boolean;
+
+   /**
+    * desc: Front solid triangle expansion
+    *
+    * front triangle expansion symbol type
+    *
+    * default: 'solid'
+    */
+   frontCaretType?: 'hollow' | 'solid';
+
+   /**
+    * desc: Front solid triangle expansion
+    *
+    * triangle expansion color
+    *
+    * default: null
+    */
+   caretColor?: string;
 
      /**
       * theme of menu

--- a/src/Menu/index.d.ts
+++ b/src/Menu/index.d.ts
@@ -115,18 +115,18 @@ Pick<StructDataStandardProps<Item>, 'renderItem'>
      frontCaret?: boolean;
 
    /**
-    * desc: Front solid triangle expansion
+    * desc: front triangle expansion symbol type
     *
-    * front triangle expansion symbol type
+    * 前置三角展开符类型
     *
     * default: 'solid'
     */
    frontCaretType?: 'hollow' | 'solid';
 
    /**
-    * desc: Front solid triangle expansion
+    * desc: triangle expansion color
     *
-    * triangle expansion color
+    * 三角展开符颜色
     *
     * default: null
     */

--- a/src/Menu/styles/menu.less
+++ b/src/Menu/styles/menu.less
@@ -3,7 +3,7 @@
 
 @menu-prefix: ~'@{so-prefix}-menu';
 @transition-duration: .2s;
-@expand-width: 40px;
+@expand-width: 32px;
 
 .@{menu-prefix} {
   position: relative;
@@ -46,19 +46,36 @@
       &:hover {
         color: @menu-item-light-hover-color;
         background-color: @menu-item-light-hover-bgc;
+        .@{menu-prefix}-expand::after {
+          border-color: @menu-item-light-hover-color;
+        }
       }
     }
+  }
 
+  & &-item {
     &.@{menu-prefix}-disabled > a {
       color: @menu-disabled-color;
       cursor: not-allowed;
+      .@{menu-prefix}-expand::after {
+        border-color: @menu-disabled-color;
+      }
+    }
+    &.@{menu-prefix}-disabled {
+      &.@{menu-prefix}-caret-solid > a.@{menu-prefix}-title .@{menu-prefix}-caret {
+        border-top-color: @menu-disabled-color!important;
+      }
+      &.@{menu-prefix}-caret-hollow > a .@{menu-prefix}-caret::after {
+        border-color: @menu-disabled-color;
+      }
+
     }
   }
 
   &-title {
     position: relative;
     height: @menu-item-height;
-    padding: 0 20px;
+    padding: 0 16px;
     line-height: @menu-item-height;
     font-size: @menu-item-font-size;
   }
@@ -140,7 +157,7 @@
         &:before {
           position: absolute;
           top: 0;
-          right: 0px;
+          right: 0;
           width: @menu-active-bar;
           height: 100%;
           background: @menu-active-bar-color;
@@ -223,7 +240,20 @@
 
   &-inline, &-horizontal {
     .@{menu-prefix}-in-path.@{menu-prefix}-has-children > a {
-      color: @colors-primary;
+      color: @menu-item-active-color;
+      .@{menu-prefix}-expand::after {
+        border-color: @menu-item-active-color;
+      }
+    }
+    .@{menu-prefix}-in-path.@{menu-prefix}-caret-solid.@{menu-prefix}-has-children > a {
+      .@{menu-prefix}-caret {
+        border-top-color: @menu-item-active-color;
+      }
+    }
+    .@{menu-prefix}-in-path.@{menu-prefix}-caret-hollow.@{menu-prefix}-has-children > a {
+      .@{menu-prefix}-caret::after {
+        border-color: @menu-item-active-color;
+      }
     }
   }
 
@@ -458,7 +488,8 @@
       .@{menu-prefix}-caret-solid {
         .@{menu-prefix}-title {
           & > .@{menu-prefix}-caret.@{menu-prefix}-has-childs {
-              border-top-color: @menu-dark-item;
+              color: @menu-dark-item;
+              border-top-color: currentColor;
           }
 
           &:hover {
@@ -468,7 +499,25 @@
           }
         }
       }
+
+      .@{menu-prefix}-caret-hollow {
+        .@{menu-prefix}-title {
+          & > .@{menu-prefix}-caret.@{menu-prefix}-has-childs{
+            color: @menu-dark-item;
+            &::after {
+              border-top-color: currentColor;
+            }
+          }
+        }
+      }
     }
+    .@{menu-prefix}-caret-hollow.@{menu-prefix}-in-path .@{menu-prefix}-title,
+    .@{menu-prefix}-caret-hollow .@{menu-prefix}-title:hover {
+      & > .@{menu-prefix}-caret.@{menu-prefix}-has-childs::after {
+        border-color: @menu-item-dark-hover-color;
+      }
+    }
+
 
     &.@{menu-prefix}-inline {
       .@{menu-prefix}-selectable {
@@ -504,7 +553,7 @@
     }
 
     & > .@{menu-prefix}-title  {
-      padding-right:  20px;
+      padding-right: 16px;
     }
   }
 
@@ -522,13 +571,44 @@
 
 
         &.@{menu-prefix}-has-childs {
-          border-top-color: @menu-item-color;
+          color: @menu-item-color;
+          border-top-color: currentColor;
         }
       }
 
       &:hover {
         & > .@{menu-prefix}-caret.@{menu-prefix}-has-childs {
           border-top-color: @menu-item-light-hover-color;
+        }
+      }
+    }
+  }
+
+  .@{menu-prefix}-caret-hollow {
+    .@{menu-prefix}-title:hover {
+      .@{menu-prefix}-caret::after {
+        border-color: @menu-item-active-color;
+      }
+    }
+    .@{menu-prefix}-caret {
+      display: inline-block;
+      width: 8px;
+      position: relative;
+      margin-left: -4px;
+      margin-right: 14px;
+    }
+    .@{menu-prefix}-caret.@{menu-prefix}-has-childs {
+      .caret-outline(down; 6px);
+      &::after {
+        transform-origin: 75% 75%;
+        transform: translateY(-4%) rotate(45deg);
+      }
+    }
+
+    &.@{menu-prefix}-has-children.@{menu-prefix}-open {
+      & > .@{menu-prefix}-title .@{menu-prefix}-caret {
+        &:after {
+          transform: translateY(-4%) rotate(225deg);
         }
       }
     }
@@ -562,8 +642,8 @@
 
     .@{menu-prefix}-has-children:not(.@{menu-prefix}-caret-solid) > .@{menu-prefix}-title {
 
-      padding-left: 40px;
-      padding-right: 20px;
+      padding-left: 32px;
+      padding-right: 16px;
 
       &:after {
         right: auto;
@@ -588,6 +668,13 @@
       .@{menu-prefix}-caret {
         margin-right: 0;
         margin-left: 8px;
+      }
+    }
+
+    .@{menu-prefix}-has-children.@{menu-prefix}-caret-hollow > .@{menu-prefix}-title{
+      .@{menu-prefix}-caret {
+        margin-left: 10px;
+        margin-right: 4px;
       }
     }
 

--- a/src/Menu/styles/menu.less
+++ b/src/Menu/styles/menu.less
@@ -63,7 +63,7 @@
     }
     &.@{menu-prefix}-disabled {
       &.@{menu-prefix}-caret-solid > a.@{menu-prefix}-title .@{menu-prefix}-caret {
-        border-top-color: @menu-disabled-color!important;
+        border-top-color: @menu-disabled-color;
       }
       &.@{menu-prefix}-caret-hollow > a .@{menu-prefix}-caret::after {
         border-color: @menu-disabled-color;

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 import './styles/normalize.less'
 import * as utils from './utils'
 
-export default { utils, version: '1.7.0-rc.7' }
+export default { utils, version: '1.7.0-rc.8' }
 export { utils }
 export { setLocale } from './locale'
 export { color, style } from './utils/expose'


### PR DESCRIPTION
1. 倒三角形支持不跟每一项的文字用的同一个颜色
2. 左侧倒三角支持换成空心的倒三角
3. 选中时，三角保持一致的效果，高亮
4. 默认的 padding-right 从 20 改为 16，与默认的 padding-left 保持对称