### PR TITLE
simple table 可拖拽 window resize 导致最后一列变形错位

### DIFF
--- a/src/Table/SimpleTable.js
+++ b/src/Table/SimpleTable.js
@@ -8,6 +8,7 @@ import Tbody from './Tbody'
 import Thead from './Thead'
 import { compareColumns } from '../utils/shallowEqual'
 import Sticky from '../Sticky'
+import { addResizeObserver } from '../utils/dom/element'
 
 function setScrollLeft(target, scrollLeft) {
   if (target && target.scrollLeft !== scrollLeft) target.scrollLeft = scrollLeft
@@ -27,10 +28,14 @@ class SimpleTable extends PureComponent {
     this.bindBody = this.bindElement.bind(this, 'body')
     this.handleScroll = this.handleScroll.bind(this)
     this.handleColgroup = this.handleColgroup.bind(this)
+    this.resetColGroup = this.resetColGroup.bind(this)
   }
 
   componentDidMount() {
     if (this.body) this.body.addEventListener('wheel', this.handleScroll, { passive: false })
+    if (this.body) {
+      this.removeReiszeObserver = addResizeObserver(this.body, this.resetColGroup, { direction: 'x' })
+    }
     this.scrollCheck()
   }
 
@@ -45,10 +50,15 @@ class SimpleTable extends PureComponent {
 
   componentWillUnmount() {
     if (this.body) this.body.removeEventListener('wheel', this.handleScroll)
+    if (this.removeReiszeObserver) this.removeReiszeObserver()
   }
 
   bindElement(key, el) {
     this[key] = el
+  }
+
+  resetColGroup() {
+    this.setState({ colgroup: undefined, resize: true })
   }
 
   scrollCheck() {

--- a/src/utils/dom/element.js
+++ b/src/utils/dom/element.js
@@ -180,5 +180,5 @@ export const addResizeObserver = (el, handler, options = {}) => {
     }
   }
   window.addEventListener('resize', handler)
-  return window.removeEventListener('resize', handler)
+  return () => window.removeEventListener('resize', handler)
 }

--- a/src/utils/dom/element.js
+++ b/src/utils/dom/element.js
@@ -146,9 +146,33 @@ export const preventPasteFile = e => {
 
 export const parsePxToNumber = str => Number(str.replace(/\s+|px/gi, ''))
 
-export const addResizeObserver = (el, handler) => {
+export const addResizeObserver = (el, handler, options = {}) => {
+  const { direction } = options
+  let h = handler
+  let lastWidth
+  let lastHeight
   if (window.ResizeObserver) {
-    let observer = new ResizeObserver(handler)
+    if (direction) {
+      lastWidth = el.clientWidth
+      lastHeight = el.clientHeight
+      h = function(entry) {
+        const { width, height } = entry[0].contentRect
+        if (direction === 'x') {
+          if (lastWidth !== width) {
+            handler(entry)
+          }
+        } else if (direction === 'y') {
+          if (lastHeight !== height) {
+            handler(entry)
+          }
+        } else {
+          handler(entry, { x: lastWidth !== width, y: lastHeight !== height })
+        }
+        lastWidth = width
+        lastHeight = height
+      }
+    }
+    let observer = new ResizeObserver(h)
     observer.observe(el)
     return () => {
       observer.disconnect()


### PR DESCRIPTION
问题描述 simpleTable 可拖拽列 最后一列的colgroup 没有渲染 resize 的时候可能会导致最后一列变形 和表头错位
解决办法 resize 的时候重新计算
codesandbox:  https://codesandbox.io/s/simpletableresizeable-resize-lastcolwrong-rtng4?file=/App.js
