### PR TITLE
修复在Form中表单元素传入defaultValue，clear数据 元素不重新渲染的问题

### DIFF
--- a/src/Form/inputable.js
+++ b/src/Form/inputable.js
@@ -102,6 +102,7 @@ export default curry(Origin =>
             formDatum.bind(name, this.handleUpdate, defaultValue, this.validate)
             this.state.value = formDatum.get(name)
           }
+          this.lastValue = this.state.value
         }
 
         if (bindInputToItem && name && !popover) bindInputToItem(this.errorName)


### PR DESCRIPTION
问题描述： 修复在Form中表单元素传入defaultValue，clear数据 元素不重新渲染的问题
问题原因： update 中会对缓存的value 进行比较 而defaultValue 没有进行缓存
codesandbox:  https://codesandbox.io/s/pr-upload-defaultvalue-clear-not-render-ey50c