### PR TITLE
fix  由于 Reac 事件委托,如果子元素会增加或者减少 快速移动 会导致会mouseLeave 失效

### DIFF
--- a/src/Rate/Rate.js
+++ b/src/Rate/Rate.js
@@ -28,7 +28,7 @@ class Rate extends PureComponent {
     const { size } = this.props
     if (!size) return undefined
     const parsed = Math.max(MIN_SIZE, parseFloat(size))
-    return { width: parsed, fontSize: parsed }
+    return { width: parsed, fontSize: parsed, position: 'relative' }
   }
 
   getScale() {
@@ -92,7 +92,7 @@ class Rate extends PureComponent {
   }
 
   renderBackground() {
-    const { background, max, disabled, allowHalf } = this.props
+    const { background, max, disabled } = this.props
     const style = this.getStyle()
     const value = this.getValue()
 
@@ -123,11 +123,15 @@ class Rate extends PureComponent {
           <span
             key={v}
             onClick={this.handleClick.bind(this, v + 1)}
-            onMouseLeave={this.handleHover.bind(this, 0)}
             onMouseMove={allowHalf ? this.handleMove.bind(this, v + 1) : undefined}
             onMouseEnter={!allowHalf ? this.handleHover.bind(this, v + 1) : undefined}
             style={style}
           >
+            {/* Fix React event onMouseLeave not triggered when moving cursor fast */}
+            <div
+              style={{ position: 'absolute', top: 0, right: 0, left: 0, bottom: 0 }}
+              onMouseLeave={this.handleHover.bind(this, 0)}
+            />
             {value > v ? this.getIcon(front, v) : <span>&nbsp;</span>}
             {highlight === v + 1 && <i className={rateClass('highlight')}>{this.getIcon(front, v)}</i>}
           </span>

--- a/test/src/Rate/__snapshots__/example.spec.js.snap
+++ b/test/src/Rate/__snapshots__/example.spec.js.snap
@@ -21,26 +21,31 @@ exports[`Snapshot test: Rate[site/pages/components/Rate/example-01-base.js] 1`] 
   </div>
   <div>
     <span>
+      <div />
       <span>
          
       </span>
     </span>
     <span>
+      <div />
       <span>
          
       </span>
     </span>
     <span>
+      <div />
       <span>
          
       </span>
     </span>
     <span>
+      <div />
       <span>
          
       </span>
     </span>
     <span>
+      <div />
       <span>
          
       </span>
@@ -71,26 +76,31 @@ exports[`Snapshot test: Rate[site/pages/components/Rate/example-01-half.js] 1`] 
   </div>
   <div>
     <span>
+      <div />
       <span>
          
       </span>
     </span>
     <span>
+      <div />
       <span>
          
       </span>
     </span>
     <span>
+      <div />
       <span>
          
       </span>
     </span>
     <span>
+      <div />
       <span>
          
       </span>
     </span>
     <span>
+      <div />
       <span>
          
       </span>
@@ -121,22 +131,27 @@ exports[`Snapshot test: Rate[site/pages/components/Rate/example-02-color.js] 1`]
   </div>
   <div>
     <span>
+      <div />
       <i />
     </span>
     <span>
+      <div />
       <i />
     </span>
     <span>
+      <div />
       <span>
          
       </span>
     </span>
     <span>
+      <div />
       <span>
          
       </span>
     </span>
     <span>
+      <div />
       <span>
          
       </span>
@@ -182,45 +197,55 @@ exports[`Snapshot test: Rate[site/pages/components/Rate/example-04-max.js] 1`] =
   </div>
   <div>
     <span>
+      <div />
       <i />
     </span>
     <span>
+      <div />
       <i />
     </span>
     <span>
+      <div />
       <i />
     </span>
     <span>
+      <div />
       <span>
          
       </span>
     </span>
     <span>
+      <div />
       <span>
          
       </span>
     </span>
     <span>
+      <div />
       <span>
          
       </span>
     </span>
     <span>
+      <div />
       <span>
          
       </span>
     </span>
     <span>
+      <div />
       <span>
          
       </span>
     </span>
     <span>
+      <div />
       <span>
          
       </span>
     </span>
     <span>
+      <div />
       <span>
          
       </span>
@@ -252,74 +277,31 @@ exports[`Snapshot test: Rate[site/pages/components/Rate/example-05-size.js] 1`] 
     </div>
     <div>
       <span>
+        <div />
         <span>
            
         </span>
       </span>
       <span>
+        <div />
         <span>
            
         </span>
       </span>
       <span>
+        <div />
         <span>
            
         </span>
       </span>
       <span>
+        <div />
         <span>
            
         </span>
       </span>
       <span>
-        <span>
-           
-        </span>
-      </span>
-      <span />
-    </div>
-  </div>
-  <br />
-  <div>
-    <div>
-      <span>
-        <i />
-      </span>
-      <span>
-        <i />
-      </span>
-      <span>
-        <i />
-      </span>
-      <span>
-        <i />
-      </span>
-      <span>
-        <i />
-      </span>
-    </div>
-    <div>
-      <span>
-        <span>
-           
-        </span>
-      </span>
-      <span>
-        <span>
-           
-        </span>
-      </span>
-      <span>
-        <span>
-           
-        </span>
-      </span>
-      <span>
-        <span>
-           
-        </span>
-      </span>
-      <span>
+        <div />
         <span>
            
         </span>
@@ -348,26 +330,84 @@ exports[`Snapshot test: Rate[site/pages/components/Rate/example-05-size.js] 1`] 
     </div>
     <div>
       <span>
+        <div />
         <span>
            
         </span>
       </span>
       <span>
+        <div />
         <span>
            
         </span>
       </span>
       <span>
+        <div />
         <span>
            
         </span>
       </span>
       <span>
+        <div />
         <span>
            
         </span>
       </span>
       <span>
+        <div />
+        <span>
+           
+        </span>
+      </span>
+      <span />
+    </div>
+  </div>
+  <br />
+  <div>
+    <div>
+      <span>
+        <i />
+      </span>
+      <span>
+        <i />
+      </span>
+      <span>
+        <i />
+      </span>
+      <span>
+        <i />
+      </span>
+      <span>
+        <i />
+      </span>
+    </div>
+    <div>
+      <span>
+        <div />
+        <span>
+           
+        </span>
+      </span>
+      <span>
+        <div />
+        <span>
+           
+        </span>
+      </span>
+      <span>
+        <div />
+        <span>
+           
+        </span>
+      </span>
+      <span>
+        <div />
+        <span>
+           
+        </span>
+      </span>
+      <span>
+        <div />
         <span>
            
         </span>
@@ -399,18 +439,23 @@ exports[`Snapshot test: Rate[site/pages/components/Rate/example-06-text.js] 1`] 
   </div>
   <div>
     <span>
+      <div />
       <i />
     </span>
     <span>
+      <div />
       <i />
     </span>
     <span>
+      <div />
       <i />
     </span>
     <span>
+      <div />
       <i />
     </span>
     <span>
+      <div />
       <span>
          
       </span>
@@ -483,20 +528,25 @@ exports[`Snapshot test: Rate[site/pages/components/Rate/example-08-face.js] 1`] 
   </div>
   <div>
     <span>
+      <div />
       <i />
     </span>
     <span>
+      <div />
       <i />
     </span>
     <span>
+      <div />
       <i />
     </span>
     <span>
+      <div />
       <span>
          
       </span>
     </span>
     <span>
+      <div />
       <span>
          
       </span>
@@ -527,26 +577,31 @@ exports[`Snapshot test: Rate[site/pages/components/Rate/example-09-array.js] 1`]
   </div>
   <div>
     <span>
+      <div />
       <span>
         A
       </span>
     </span>
     <span>
+      <div />
       <span>
         B
       </span>
     </span>
     <span>
+      <div />
       <span>
          
       </span>
     </span>
     <span>
+      <div />
       <span>
          
       </span>
     </span>
     <span>
+      <div />
       <span>
          
       </span>
@@ -577,26 +632,31 @@ exports[`Snapshot test: Rate[site/pages/components/Rate/example-10-clearable.js]
   </div>
   <div>
     <span>
+      <div />
       <span>
          
       </span>
     </span>
     <span>
+      <div />
       <span>
          
       </span>
     </span>
     <span>
+      <div />
       <span>
          
       </span>
     </span>
     <span>
+      <div />
       <span>
          
       </span>
     </span>
     <span>
+      <div />
       <span>
          
       </span>


### PR DESCRIPTION
fix  由于 Reac 事件委托,如果子元素会增加或者减少 快速移动 会导致会mouseLeave 失效