### PR TITLE
修复 table  拖动行实际渲染会比max 大的问题

### DIFF
--- a/src/Table/resizable.js
+++ b/src/Table/resizable.js
@@ -48,7 +48,7 @@ export default Table =>
       const { onColumnResize } = this.props
       const changed = immer(this.state, draft => {
         const column = draft.columns[index]
-        draft.delta += parseFloat(width - (column.width || 0))
+        draft.delta += parseFloat(width - (column.width || colgroup[index] || 0))
         colgroup[index] = width
         draft.columns.forEach((col, i) => {
           const w = colgroup[i]


### PR DESCRIPTION
问题原因： resize 处理函数中计算 宽度增量 当columns 没有传width 的时候计算错误了