### PR TITLE
fix: 修复 TreeSelect 多选并且设置 absolute 下, 值改变后没有更新下拉框位置

### DIFF
--- a/src/TreeSelect/TreeSelect.js
+++ b/src/TreeSelect/TreeSelect.js
@@ -227,7 +227,7 @@ export default class TreeSelect extends PureComponent {
 
   renderTreeOptions() {
     const { focus, position } = this.state
-    const { multiple, datum, data, absolute, height, zIndex } = this.props
+    const { multiple, datum, data, absolute, height, zIndex, compressed, value } = this.props
     const props = {}
     ;[
       'mode',
@@ -280,6 +280,7 @@ export default class TreeSelect extends PureComponent {
         style={{ maxHeight: height, overflowY: 'auto' }}
         fixed="min"
         zIndex={zIndex}
+        value={multiple && !compressed ? value : undefined}
       >
         <div className={treeSelectClass('tree-wrapper')}>{content}</div>
       </OptionList>


### PR DESCRIPTION
问题描述： TreeSelect 设置multiple 和 absolute 属性， 选择值可能导致下拉框被撑开此时需要更新 下拉列表位置