### PR TITLE
### 1.8.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shineout",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "description": "Shein 前端组件库",
   "main": "./lib/index.js",
   "module": "./es/index.js",

--- a/site/pages/documentation/changelog/1.x.x.md
+++ b/site/pages/documentation/changelog/1.x.x.md
@@ -1,5 +1,12 @@
 # 更新日志
 
+### 1.8.6
+- 新增 Popover.Content 组件 ，默认有 padding 和 maxWidth 样式
+- 优化 Popover.Confirm 支持 type = "warning" 使用默认warning图标
+- 修复 TreeSelect 多选并且设置 absolute 时，下拉框位置可能渲染不正确的问题
+- 修复 List 组件 传入 fixe 属性后无法受控的问题
+- 修复 Input 同时配置 min, max, rules={\[rules.max(XXX), rules.min(XXX)\]} 会导致校验文案错误
+
 ### 1.8.5
 - 修复 Select maxLength 输入中文问题
 - 修复 Form.Field 会导致内部组件 disabled 无效的问题


### PR DESCRIPTION
- 新增 Popover.Content 组件 ，默认有 padding 和 maxWidth 样式
- 优化 Popover.Confirm 支持 type = "warning" 使用默认warning图标
- 修复 TreeSelect 多选并且设置 absolute 时，下拉框位置可能渲染不正确的问题
- 修复 List 组件 传入 fixe 属性后无法受控的问题
- 修复 Input 同时配置 min, max, rules={[rules.max(XXX), rules.min(XXX)]}, 会导致校验文案错误