### PR TITLE
fix:  Tab内嵌Table切换列错位的问题

### DIFF
--- a/src/Cascader/Result.js
+++ b/src/Cascader/Result.js
@@ -56,7 +56,7 @@ class Result extends PureComponent {
     datum.subscribe(CHANGE_TOPIC, this.handleUpdate)
     const { compressed } = this.props
     if (compressed) {
-      this.cancelResizeObserver = addResizeObserver(this.resultEl, this.resetMore)
+      this.cancelResizeObserver = addResizeObserver(this.resultEl, this.resetMore, { direction: 'x' })
     }
   }
 

--- a/src/Select/Result.js
+++ b/src/Select/Result.js
@@ -72,7 +72,7 @@ class Result extends PureComponent {
   componentDidMount() {
     const { compressed } = this.props
     if (compressed) {
-      this.cancelResizeObserver = addResizeObserver(this.resultEl, this.resetMore)
+      this.cancelResizeObserver = addResizeObserver(this.resultEl, this.resetMore, { direction: 'x' })
     }
   }
 

--- a/src/Table/SimpleTable.js
+++ b/src/Table/SimpleTable.js
@@ -59,6 +59,7 @@ class SimpleTable extends PureComponent {
   }
 
   resetColGroup() {
+    this.lastColGroup = this.state.colgroup || this.lastColGroup
     this.setState({ colgroup: undefined, resize: true })
   }
 
@@ -100,7 +101,8 @@ class SimpleTable extends PureComponent {
     const { colgroup, scrollAble } = this.state
     const inner = (
       <table style={{ width }} className={tableClass(bordered && 'table-bordered')}>
-        <Colgroup colgroup={colgroup} columns={columns} resizable={columnResizable} />
+        {/* keep thead colgroup stable */}
+        <Colgroup colgroup={colgroup || this.lastColGroup} columns={columns} resizable={columnResizable} />
         <Thead {...this.props} colgroup={colgroup} onSortChange={this.handleSortChange} onColChange={onResize} />
       </table>
     )

--- a/src/TreeSelect/Result.js
+++ b/src/TreeSelect/Result.js
@@ -50,7 +50,7 @@ class Result extends PureComponent {
   componentDidMount() {
     const { compressed } = this.props
     if (compressed) {
-      this.cancelResizeObserver = addResizeObserver(this.resultEl, this.resetMore)
+      this.cancelResizeObserver = addResizeObserver(this.resultEl, this.resetMore, { direction: 'x' })
     }
   }
 

--- a/src/utils/dom/element.js
+++ b/src/utils/dom/element.js
@@ -160,15 +160,15 @@ export const addResizeObserver = (el, handler, options = {}) => {
       lastHeight = el.clientHeight
       h = function(entry) {
         const { width, height } = entry[0].contentRect
-        if (direction === 'x') {
+        if (width && direction === 'x') {
           if (lastWidth !== width) {
             handler(entry)
           }
         } else if (direction === 'y') {
-          if (lastHeight !== height) {
+          if (height && lastHeight !== height) {
             handler(entry)
           }
-        } else {
+        } else if (width && height) {
           handler(entry, { x: lastWidth !== width, y: lastHeight !== height })
         }
         lastWidth = width


### PR DESCRIPTION
问题描述：Tabs  内嵌 SimpleTable 切换Tab列错位的问题
问题原因：display: none 会触发 resizeObserver
复线地址：https://codesandbox.io/s/tabnei-qian-tao-simpletableqie-huan-hou-lie-cuo-wei-8ybh2e