### PR TITLE
fix: Input 组件 在手动清空数据 然后粘贴原来一样的值 就会出现卡顿 ，因为 delay 内部受控了value 存在state …

### DIFF
--- a/src/hoc/delay.js
+++ b/src/hoc/delay.js
@@ -45,6 +45,7 @@ export default curry(
         this.setState({ value })
 
         this.changeLocked = true
+        this.forceUpdate()
         if (this.changeTimer) clearTimeout(this.changeTimer)
         this.changeTimer = setTimeout(() => {
           this.changeLocked = false


### PR DESCRIPTION
…里面 ，delay是pureComponent 然后这种情况下会导致不更新