### PR TITLE
fix: Cascader innertitle not has hidable class

### DIFF
--- a/src/TreeSelect/Result.js
+++ b/src/TreeSelect/Result.js
@@ -178,7 +178,7 @@ class Result extends PureComponent {
         className={classnames(
           inputClass('placeholder'),
           treeSelectClass('ellipsis'),
-          innerTitle && inputTitleClass('item')
+          innerTitle && inputTitleClass('hidable')
         )}
       >
         {this.props.placeholder}

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 // Created by scripts/src-index.js.
 import * as utils from './utils'
 
-export default { utils, version: '1.9.0-rc.7' }
+export default { utils, version: '1.9.0-rc.8' }
 export { utils }
 export { setLocale } from './locale'
 export { color, style } from './utils/expose'


### PR DESCRIPTION
Cascader 内嵌标题 class 写错 导致 placeholder 和 innerTitle 重叠