### PR TITLE
fix: clientWidth Ignore the decimal point

### DIFF
--- a/src/Table/SimpleTable.js
+++ b/src/Table/SimpleTable.js
@@ -79,7 +79,7 @@ class SimpleTable extends PureComponent {
     const { columns } = this.props
     const colgroup = []
     for (let i = 0, count = tds.length; i < count; i++) {
-      const width = tds[i].offsetWidth
+      const { width } = tds[i].getBoundingClientRect()
       const colSpan = parseInt(tds[i].getAttribute('colspan'), 10)
       if (colSpan > 1) {
         split(width, range(colSpan).map(j => columns[i + j].width)).forEach(w => colgroup.push(w))


### PR DESCRIPTION
修复 table 计算 colgroup clientWidth 忽略的小数点 在高分辨率显示器下会存在精度问题 导致出现不该有的滚动条