### PR TITLE
fix: form setValue time

### DIFF
--- a/src/Datum/hoc.js
+++ b/src/Datum/hoc.js
@@ -67,11 +67,6 @@ export default curry((options, Origin) => {
       if (prevProps.onChange !== this.props.onChange) {
         this.datum.onChange = this.props.onChange
       }
-      const values = this.props[key]
-      if (values !== this.prevValues) {
-        this.setValue(this.props.initValidate ? undefined : IGNORE_VALIDATE)
-        this.prevValues = values
-      }
     }
 
     setValue(t) {
@@ -85,6 +80,11 @@ export default curry((options, Origin) => {
       if (onDatumBind) onDatumBind(this.datum)
       if (bindProps.includes('disabled')) {
         this.datum.setDisabled(props.disabled)
+      }
+      const values = this.props[key]
+      if (values !== this.prevValues) {
+        this.setValue(this.props.initValidate ? undefined : IGNORE_VALIDATE)
+        this.prevValues = values
       }
 
       if (type === 'list') this.setValue(WITH_OUT_DISPATCH)

--- a/test/src/Form/Form.spec.js
+++ b/test/src/Form/Form.spec.js
@@ -8,23 +8,23 @@ class F extends React.Component {
     this.state = {
       value: {
         a: '1',
-        input: true,
         fuck: 'hello',
       },
       show: true,
+      input: true,
     }
   }
 
   render() {
-    const { show, value } = this.state
+    const { show, value, input } = this.state
 
     return (
       <div>
         <Button onClick={() => this.setState({ show: false, value: { b: 'c' } })}>hidden</Button>
-        <Button onClick={() => this.setState({ value: { input: false } })}>hidden</Button>
+        <Button onClick={() => this.setState({ input: false })}>hidden</Button>
         {show && (
           <Form value={value} onChange={this.props.onChange}>
-            {value.input && <Input name="fuck" />}
+            {input && <Input name="fuck" />}
           </Form>
         )}
       </div>
@@ -45,6 +45,6 @@ describe('Form[Base]', () => {
       .simulate('click')
     wrapper.update()
     jest.runAllTimers()
-    expect(fn).toBeCalledWith({ input: false })
+    expect(fn).toBeCalledWith({ a: '1' })
   })
 })


### PR DESCRIPTION
value 改变后 在didupdate 才会 更新datum 导致， 导致改次render 获取的value 为之前的，在某些情况下有问题，
1. 动态渲染的表单组件defaultValue 有值 触发表单onChange的数据为老的数据
2. 当表单组件类型改变 value 的数据类型修改后，会触发一次类型错误