### PR TITLE
fix：Pagination Jumper value is 0 while total is empty or null

### DIFF
--- a/src/Pagination/Jumper.js
+++ b/src/Pagination/Jumper.js
@@ -17,7 +17,7 @@ class Jumper extends PureComponent {
 
   getMax() {
     const { total, pageSize } = this.props
-    return Math.ceil(total / pageSize)
+    return Math.ceil(total / pageSize) || 1
   }
 
   handleKeyDown(e) {

--- a/test/src/Pagination/Pagination.spec.js
+++ b/test/src/Pagination/Pagination.spec.js
@@ -70,6 +70,18 @@ describe('Pagination[Base]', () => {
         .prop('disabled')
     ).toBeTruthy()
   })
+  test('should jumper size is 1 while total is empty or null', () => {
+    const wrapper = mount(<Pagination total={0} pageSize={50} layout={['jumper']} />)
+
+    const wrapperInput = wrapper.find('Jumper').find('input')
+    wrapperInput.simulate('change', {
+      target: {
+        value: '0',
+      },
+    })
+    wrapperInput.simulate('keydown', { keyCode: 13 })
+    expect(wrapper.find('Jumper').prop('current')).toBe(1)
+  })
 })
 
 describe('Pagination[Size]', () => {


### PR DESCRIPTION
复现地址：https://codesandbox.io/s/pagination-jumper-80bk0n?file=/App.js
问题原因：当total为0 时，计算出的max也为0
解决办法： getMax函数兜底为 1