### PR TITLE
fix cascader select treeSelect compressed when data sync update

### DIFF
--- a/site/pages/components/Select/example-01-multiple.js
+++ b/site/pages/components/Select/example-01-multiple.js
@@ -20,7 +20,7 @@ const data = [
 export default class extends Component {
   constructor(props) {
     super(props)
-    this.state = { value: 'pink' }
+    this.state = { value: ['pink'] }
   }
 
   handleChange = (value, d, c) => {

--- a/src/Cascader/Result.js
+++ b/src/Cascader/Result.js
@@ -61,20 +61,7 @@ class Result extends PureComponent {
   }
 
   componentDidUpdate(preProps) {
-    const { compressed, value = [], onFilter } = this.props
-    if (compressed) {
-      if ((preProps.value || []).join('') !== (value || []).join('')) {
-        this.resetMore()
-      } else if (value.length && this.shouldResetMore) {
-        this.shouldResetMore = false
-        this.state.more = getResetMore(
-          onFilter,
-          this.resultEl,
-          this.resultEl.querySelectorAll(`.${cascaderClass('item')}`)
-        )
-        this.forceUpdate()
-      }
-    }
+    this.updateMore(preProps)
   }
 
   componentWillUnmount() {
@@ -89,6 +76,25 @@ class Result extends PureComponent {
 
   bindResult(el) {
     this.resultEl = el
+  }
+
+  updateMore(preProps) {
+    const { compressed, value = [], onFilter, data } = this.props
+    if (compressed) {
+      if ((preProps.value || []).join('') !== (value || []).join('')) {
+        this.resetMore()
+      } else if ((preProps.data || []).length !== (data || []).length) {
+        this.resetMore()
+      } else if (value.length && this.shouldResetMore) {
+        this.shouldResetMore = false
+        this.state.more = getResetMore(
+          onFilter,
+          this.resultEl,
+          this.resultEl.querySelectorAll(`.${cascaderClass('item')}`)
+        )
+        this.forceUpdate()
+      }
+    }
   }
 
   resetMore() {
@@ -301,6 +307,7 @@ Result.propTypes = {
   showList: PropTypes.func,
   size: PropTypes.string,
   showArrow: PropTypes.bool,
+  data: PropTypes.array,
 }
 
 Result.defaultProps = {

--- a/src/Select/Result.js
+++ b/src/Select/Result.js
@@ -79,9 +79,37 @@ class Result extends PureComponent {
   }
 
   componentDidUpdate(preProps) {
-    const { result, compressed, onFilter } = this.props
+    this.updateMore(preProps)
+  }
+
+  componentWillUnmount() {
+    if (this.cancelResizeObserver) this.cancelResizeObserver()
+  }
+
+  bindResult(el) {
+    this.resultEl = el
+  }
+
+  updateMore(preProps) {
+    const { result, compressed, onFilter, renderResult, renderUnmatched } = this.props
     if (compressed) {
-      if ((preProps.result || []).join('') !== (result || []).join('')) {
+      let shouldRest = false
+      if (preProps.result.length !== result.length) {
+        shouldRest = true
+      } else {
+        let i = preProps.result.length - 1
+        while (i >= 0) {
+          const before = getResultContent(preProps.result[i], preProps.renderResult, preProps.renderUnmatched)
+          const now = getResultContent(result[i], renderResult, renderUnmatched)
+          if (before !== now) {
+            shouldRest = true
+            break
+          }
+          i -= 1
+        }
+      }
+
+      if (shouldRest) {
         this.resetMore()
       } else if (result.length && this.shouldResetMore) {
         this.shouldResetMore = false
@@ -93,14 +121,6 @@ class Result extends PureComponent {
         this.forceUpdate()
       }
     }
-  }
-
-  componentWillUnmount() {
-    if (this.cancelResizeObserver) this.cancelResizeObserver()
-  }
-
-  bindResult(el) {
-    this.resultEl = el
   }
 
   resetMore() {

--- a/src/TreeSelect/Result.js
+++ b/src/TreeSelect/Result.js
@@ -57,9 +57,37 @@ class Result extends PureComponent {
   }
 
   componentDidUpdate(preProps) {
-    const { result, compressed, onFilter } = this.props
+    this.updateMore(preProps)
+  }
+
+  componentWillUnmount() {
+    if (this.cancelResizeObserver) this.cancelResizeObserver()
+  }
+
+  bindResult(el) {
+    this.resultEl = el
+  }
+
+  updateMore(preProps) {
+    const { result, compressed, onFilter, renderResult, renderUnmatched } = this.props
     if (compressed) {
-      if ((preProps.result || []).join('') !== (result || []).join('')) {
+      let shouldRest = false
+      if (preProps.result.length !== result.length) {
+        shouldRest = true
+      } else {
+        let i = preProps.result.length - 1
+        while (i >= 0) {
+          const before = getResultContent(preProps.result[i], preProps.renderResult, preProps.renderUnmatched)
+          const now = getResultContent(result[i], renderResult, renderUnmatched)
+          if (before !== now) {
+            shouldRest = true
+            break
+          }
+          i -= 1
+        }
+      }
+
+      if (shouldRest) {
         this.resetMore()
       } else if (result.length && this.shouldResetMore) {
         this.shouldResetMore = false
@@ -71,14 +99,6 @@ class Result extends PureComponent {
         this.forceUpdate()
       }
     }
-  }
-
-  componentWillUnmount() {
-    if (this.cancelResizeObserver) this.cancelResizeObserver()
-  }
-
-  bindResult(el) {
-    this.resultEl = el
   }
 
   resetMore() {


### PR DESCRIPTION
问题描述： 当先传入value， 后 异步加载到数据时候 会存在重新计算截断导致布局错乱的情况
解决办法：比较实际渲染的result 或者 在cascader 中比较data 长度变化 后重新计算