### PR TITLE
Fix table on column resize nodata

### DIFF
--- a/src/Table/SimpleTable.js
+++ b/src/Table/SimpleTable.js
@@ -29,6 +29,7 @@ class SimpleTable extends PureComponent {
     this.handleScroll = this.handleScroll.bind(this)
     this.handleColgroup = this.handleColgroup.bind(this)
     this.resetColGroup = this.resetColGroup.bind(this)
+    this.getHeader = this.getHeader.bind(this)
   }
 
   componentDidMount() {
@@ -47,6 +48,10 @@ class SimpleTable extends PureComponent {
   componentWillUnmount() {
     if (this.body) this.body.removeEventListener('wheel', this.handleScroll)
     if (this.removeReiszeObserver) this.removeReiszeObserver()
+  }
+
+  getHeader({ el }) {
+    this.headerEl = el
   }
 
   bindElement(key, el) {
@@ -76,11 +81,13 @@ class SimpleTable extends PureComponent {
   }
 
   handleColgroup(tds) {
+    const items = tds || (this.headerEl && this.headerEl.querySelectorAll('th'))
+    if (!items) return
     const { columns } = this.props
     const colgroup = []
-    for (let i = 0, count = tds.length; i < count; i++) {
-      const { width } = tds[i].getBoundingClientRect()
-      const colSpan = parseInt(tds[i].getAttribute('colspan'), 10)
+    for (let i = 0, count = items.length; i < count; i++) {
+      const { width } = items[i].getBoundingClientRect()
+      const colSpan = parseInt(items[i].getAttribute('colspan'), 10)
       if (colSpan > 1) {
         split(width, range(colSpan).map(j => columns[i + j].width)).forEach(w => colgroup.push(w))
       } else {
@@ -103,7 +110,13 @@ class SimpleTable extends PureComponent {
       <table style={{ width }} className={tableClass(bordered && 'table-bordered')}>
         {/* keep thead colgroup stable */}
         <Colgroup colgroup={colgroup || this.lastColGroup} columns={columns} resizable={columnResizable} />
-        <Thead {...this.props} colgroup={colgroup} onSortChange={this.handleSortChange} onColChange={onResize} />
+        <Thead
+          {...this.props}
+          onHeaderRender={this.getHeader}
+          colgroup={colgroup}
+          onSortChange={this.handleSortChange}
+          onColChange={onResize}
+        />
       </table>
     )
     const empty = data.length === 0

--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -116,7 +116,7 @@ class Table extends Component {
     }
 
     const isEmpty = (!data || data.length === 0) && !children
-    const useSeparate = fixed && !isEmpty
+    const useSeparate = fixed
     const ResizeSepTable = columnResizable ? ResizeSeperateTable : SeperateTable
     const ResizeSimTable = columnResizable ? ResizeSimpleTable : SimpleTable
     const RenderTable = useSeparate ? ResizeSepTable : ResizeSimTable

--- a/src/Table/Tbody.js
+++ b/src/Table/Tbody.js
@@ -87,6 +87,8 @@ class Tbody extends PureComponent {
     if (!onBodyRender || !this.body) return
     datum.unsubscribe(RENDER_COL_GROUP_EVENT, this.bodyRender)
     if (this.body.clientHeight === 0) {
+      this.colgroupSetted = true
+      onBodyRender(null)
       datum.subscribe(RENDER_COL_GROUP_EVENT, this.bodyRender)
       return
     }

--- a/src/Table/Thead.js
+++ b/src/Table/Thead.js
@@ -16,6 +16,14 @@ class Thead extends PureComponent {
     this.handleMouseDown = this.handleResize.bind(this, 'mousedown')
     this.handleMouseMove = this.handleResize.bind(this, 'mousemove')
     this.handleMouseUp = this.handleResize.bind(this, 'mouseup')
+    this.bindHeader = this.bindHeader.bind(this)
+  }
+
+  componentDidMount() {
+    const { onHeaderRender } = this.props
+    if (onHeaderRender) {
+      onHeaderRender(this)
+    }
   }
 
   setColumns(columns, col, level, index = 0) {
@@ -58,6 +66,10 @@ class Thead extends PureComponent {
     }
 
     return colSpan
+  }
+
+  bindHeader(el) {
+    this.el = el
   }
 
   resizeColgroup(deltaX) {
@@ -214,7 +226,7 @@ class Thead extends PureComponent {
     const trs = this.formatTrs()
 
     return (
-      <thead>
+      <thead ref={this.bindHeader}>
         {trs.map((tr, i) => (
           <tr key={i}>{tr}</tr>
         ))}
@@ -238,6 +250,7 @@ Thead.propTypes = {
   treeCheckAll: PropTypes.bool,
   colgroup: PropTypes.array,
   renderSorter: PropTypes.func,
+  onHeaderRender: PropTypes.func,
 }
 
 Thead.defaultProps = {

--- a/src/Table/emptyDom.js
+++ b/src/Table/emptyDom.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { compareColumns } from 'shineout/utils/shallowEqual'
+
+class EmptyDom extends React.PureComponent {
+  componentDidMount() {
+    if (this.props.onEmptyRender) {
+      this.props.onEmptyRender()
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (!compareColumns(prevProps.columns, this.props.columns)) {
+      setTimeout(() => {
+        this.props.onEmptyRender()
+      })
+    }
+  }
+
+  render() {
+    return <div />
+  }
+}
+EmptyDom.propTypes = {
+  onEmptyRender: PropTypes.func,
+  columns: PropTypes.any,
+}
+
+export default EmptyDom

--- a/src/Table/resizable.js
+++ b/src/Table/resizable.js
@@ -44,11 +44,14 @@ export default Table =>
       return width
     }
 
-    handleResize(index, width, colgroup) {
+    handleResize(index, width, colgroup = []) {
       const { onColumnResize } = this.props
       const changed = immer(this.state, draft => {
         const column = draft.columns[index]
-        draft.delta += parseFloat(width - (column.width || colgroup[index] || 0))
+        const beforeWidth = column.width || colgroup[index]
+        if (beforeWidth) {
+          draft.delta += parseFloat(width - beforeWidth)
+        }
         colgroup[index] = width
         draft.columns.forEach((col, i) => {
           const w = colgroup[i]


### PR DESCRIPTION
问题描述： Table 组件 data = [] , columnResizable 为true, 当resize 一个列的时候会导致页面报错
问题原因： Table resize 的时候会取 colgroup 数据 而没有data 的时候 colgroup 为 undefined
解决办法： 处理colgroup 为 undefined 的情况