### PR TITLE
fix: listDatum 手动修改 value 导致触发 onChange 的 问题

### DIFF
--- a/src/Datum/hoc.js
+++ b/src/Datum/hoc.js
@@ -82,7 +82,7 @@ export default curry((options, Origin) => {
         this.datum.setDisabled(props.disabled)
       }
       const values = this.props[key]
-      if (values !== this.prevValues) {
+      if (type === 'form' && values !== this.prevValues) {
         this.setValue(this.props.initValidate ? undefined : IGNORE_VALIDATE)
         this.prevValues = values
       }


### PR DESCRIPTION
问题描述， ListDatum 手动修改 value 导致触发 onChange ，如果在onChange的时候再次修改value 值就会触发无限循环。
问题原因： 之前修复form  value 获取存在延迟的问题， 修改了部分逻辑 导致了 手动修改 value 导致触发 onChange