### PR TITLE
fix: select compressed 当 renderResult 返回 dom 的时候会存在页面报错

### DIFF
--- a/src/Select/Result.js
+++ b/src/Select/Result.js
@@ -11,6 +11,7 @@ import Caret from '../icons/Caret'
 import { isRTL } from '../config'
 import More, { getResetMore } from './More'
 import InputTitle from '../InputTitle'
+import { getKey } from '../utils/uid'
 
 export const IS_NOT_MATCHED_VALUE = 'IS_NOT_MATCHED_VALUE'
 
@@ -91,24 +92,23 @@ class Result extends PureComponent {
   }
 
   updateMore(preProps) {
-    const { result, compressed, onFilter, renderResult, renderUnmatched } = this.props
+    const { result, compressed, onFilter, keygen, data } = this.props
     if (compressed) {
       let shouldRest = false
-      if (preProps.result.length !== result.length) {
+      if (preProps.result.length !== result.length || (data || []).length !== (preProps.data || []).length) {
         shouldRest = true
-      } else {
+      } else if (preProps.result !== result) {
+        const getUnMatchKey = (d, k) => (d && d.IS_NOT_MATCHED_VALUE ? d.value : getKey(d, k))
+        const isSameData = (data1, data2, k) => getUnMatchKey(data1, k) === getUnMatchKey(data2, k)
         let i = preProps.result.length - 1
         while (i >= 0) {
-          const before = getResultContent(preProps.result[i], preProps.renderResult, preProps.renderUnmatched)
-          const now = getResultContent(result[i], renderResult, renderUnmatched)
-          if (before !== now) {
+          if (!isSameData(result[i], preProps.result[i], keygen)) {
             shouldRest = true
             break
           }
           i -= 1
         }
       }
-
       if (shouldRest) {
         this.resetMore()
       } else if (result.length && this.shouldResetMore) {
@@ -393,6 +393,8 @@ Result.propTypes = {
   resultClassName: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   maxLength: PropTypes.number,
   innerTitle: PropTypes.node,
+  keygen: PropTypes.any,
+  data: PropTypes.array,
 }
 
 export default Result

--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -532,6 +532,8 @@ class Select extends PureComponent {
       resultClassName,
       maxLength,
       innerTitle,
+      keygen,
+      data,
     } = this.props
     const className = selectClass(
       'inner',
@@ -582,6 +584,8 @@ class Select extends PureComponent {
           compressedClassName={compressedClassName}
           resultClassName={resultClassName}
           innerTitle={innerTitle}
+          keygen={keygen}
+          data={data}
         />
         {this.renderOptions()}
       </div>

--- a/src/TreeSelect/Result.js
+++ b/src/TreeSelect/Result.js
@@ -10,6 +10,7 @@ import Input from './Input'
 import Caret from '../icons/Caret'
 import More, { getResetMore } from '../Select/More'
 import InputTitle from '../InputTitle'
+import { getKey } from '../utils/uid'
 
 export const IS_NOT_MATCHED_VALUE = 'IS_NOT_MATCHED_VALUE'
 
@@ -69,17 +70,17 @@ class Result extends PureComponent {
   }
 
   updateMore(preProps) {
-    const { result, compressed, onFilter, renderResult, renderUnmatched } = this.props
+    const { result, compressed, onFilter, keygen, data } = this.props
     if (compressed) {
       let shouldRest = false
-      if (preProps.result.length !== result.length) {
+      if (preProps.result.length !== result.length || (data || []).length !== (preProps.data || []).length) {
         shouldRest = true
-      } else {
+      } else if (preProps.result !== result) {
         let i = preProps.result.length - 1
         while (i >= 0) {
-          const before = getResultContent(preProps.result[i], preProps.renderResult, preProps.renderUnmatched)
-          const now = getResultContent(result[i], renderResult, renderUnmatched)
-          if (before !== now) {
+          const getUnMatchKey = (d, k) => (d && d.IS_NOT_MATCHED_VALUE ? d.value : getKey(d, k))
+          const isSameData = (data1, data2, k) => getUnMatchKey(data1, k) === getUnMatchKey(data2, k)
+          if (!isSameData(result[i], preProps.result[i], keygen)) {
             shouldRest = true
             break
           }
@@ -286,6 +287,8 @@ Result.propTypes = {
   compressed: PropTypes.bool,
   renderUnmatched: PropTypes.func,
   innerTitle: PropTypes.node,
+  keygen: PropTypes.any,
+  data: PropTypes.array,
 }
 
 export default Result

--- a/src/TreeSelect/TreeSelect.js
+++ b/src/TreeSelect/TreeSelect.js
@@ -323,6 +323,8 @@ export default class TreeSelect extends PureComponent {
       result,
       renderUnmatched,
       innerTitle,
+      keygen,
+      data,
     } = this.props
     const className = treeSelectClass(
       'inner',
@@ -361,6 +363,8 @@ export default class TreeSelect extends PureComponent {
           compressed={compressed}
           renderUnmatched={renderUnmatched}
           innerTitle={innerTitle}
+          keygen={keygen}
+          data={data}
         />
         {this.renderTreeOptions()}
       </div>


### PR DESCRIPTION
问题原因： 更新后比较结果是否改变 使用了 renderResult 的结果 进对比， 当返回结果为dom 的时候 比价会永远不想等（因为是是对象）
解决办法: 使用keygen 结果进行对比