### PR TITLE
Fix input regexp

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shineout",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "Shein 前端组件库",
   "main": "./lib/index.js",
   "module": "./es/index.js",

--- a/site/pages/documentation/changelog/1.x.x.md
+++ b/site/pages/documentation/changelog/1.x.x.md
@@ -1,4 +1,8 @@
 # 更新日志
+### 1.10.2
+- 修复 Table 中的按钮样式问题(1.10.0 - 1.10.1)
+- 修复 Input 组件 digits 功能在 safari 浏览器不兼容的问题(1.10.0 - 1.10.1)
+
 ### 1.10.1
 - 修复 Select 当 renderResult 返回dom 节点，并设置 compressed 后组件报错问题
 - 修复 Table Select 当手动修改 value 后会触发 onChange 的问题

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -16,7 +16,7 @@ function fillNumber(val) {
     val
       .replace(/^(-)?(\.\d+)(?!=\.).*/g, '$10$2')
       // eslint-disable-next-line no-useless-escape
-      .replace(/(?<=-|^)0+(?=0\.?|[^0\.])/g, '')
+      .replace(/(-|^)0+(?=0\.?|[^0\.])/g, '$0')
       .replace(/\.$/, '')
   )
 }


### PR DESCRIPTION
修复 safari 不支持 反向预查的正则