### PR TITLE
fix-table-rowSpan-nextRow-bug

### DIFF
--- a/src/Table/Tbody.js
+++ b/src/Table/Tbody.js
@@ -26,7 +26,7 @@ function format(columns, data, nextRow, index, expandKeys) {
     if (cell.colSpan < 1) cell.colSpan = 1
 
     const { rowSpan } = col
-    if (rowSpan && nextRow) {
+    if (rowSpan && nextRow && nextRow[i]) {
       if (col.type !== 'checkbox') {
         cell.content = typeof col.render === 'string' ? data[col.render] : col.render(data, index)
       }


### PR DESCRIPTION
当前面的列同时配置 `colSpan`、`rowSpan`，渲染时当 `colSpan` 包含当前列，会设置 `nextRow[i]` 设为 `null`。执行到当前列时，如果当前列配置 `rowSpan`，执行 `nextRow[i].xxxx` 代码报错。