### PR TITLE
fixed:当表头分组时，开启 columnResizable 进行拖拽，定位列错误

### DIFF
--- a/src/Table/Thead.js
+++ b/src/Table/Thead.js
@@ -86,7 +86,12 @@ class Thead extends PureComponent {
       const { target } = e
       this.resizingTh = getParent(target, 'th')
       this.resizingTable = getParent(target, 'table')
-      this.resizingIndex = [].indexOf.call(getParent(target, 'tr').children, this.resizingTh)
+      const thList = getParent(target, 'tr').children
+      const indexInTr = [].indexOf.call(thList, this.resizingTh)
+      this.resizingIndex = [].slice.call(thList, 0, indexInTr).reduce((total, th) => {
+        let count = Number(th.getAttribute('colspan')) || 1
+        return total + count
+      }, 0)
       this.resizingCol = this.resizingTable.querySelectorAll('col')[this.resizingIndex]
       this.resizingTable.classList.add(tableClass('resizing'))
       this.resizingTh.classList.add(tableClass('resizing-item'))


### PR DESCRIPTION
复现案例：[https://codesandbox.io/s/boring-pond-36rhnl?file=/App.js:0-897](https://codesandbox.io/s/boring-pond-36rhnl?file=/App.js:0-897)

修复方法：计算 `th` 下标时判断 `colspan` 属性值