### PR TITLE
fix: 修复Select disabled 属性存在判断歧义。处理方式为内部转化为bool。

### DIFF
--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -90,8 +90,6 @@ class Select extends PureComponent {
   }
 
   getDisabledStatus() {
-    if (this.props.disabled == undefined) return undefined
-
     if (typeof this.props.disabled == 'function') {
       return this.props.disabled
     } else {

--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -89,6 +89,16 @@ class Select extends PureComponent {
     return this.props.text[key] || getLocale(key)
   }
 
+  getDisabledStatus() {
+    if (this.props.disabled == undefined) return undefined
+
+    if (typeof this.props.disabled == 'function') {
+      return this.props.disabled
+    } else {
+      return !!this.props.disabled
+    }
+  }
+
   getFocusSelected() {
     const { reFocus, focusSelected } = this.props
     if (reFocus) return false
@@ -157,7 +167,7 @@ class Select extends PureComponent {
   }
 
   handleState(focus, e) {
-    if (this.props.disabled === true) return
+    if (this.getDisabledStatus() === true) return
     if (focus === this.state.focus) return
     // click close icon
     if (focus && e && e.target.classList.contains(selectClass('close'))) return
@@ -182,8 +192,8 @@ class Select extends PureComponent {
   }
 
   handleChange(_, data, fromInput) {
-    const { datum, multiple, disabled, emptyAfterSelect, onFilter, filterText, onCreate, reFocus } = this.props
-    if (disabled === true) return
+    const { datum, multiple, emptyAfterSelect, onFilter, filterText, onCreate, reFocus } = this.props
+    if (this.getDisabledStatus() === true) return
 
     // if click option, ignore blur event
     if (this.inputBlurTimer) {
@@ -410,29 +420,29 @@ class Select extends PureComponent {
     const { focus, position } = this.state
     const { optionWidth } = this.props
     const props = {}
-    ;[
-      'treeData',
-      'expanded',
-      'onExpand',
-      'loader',
-      'defaultExpanded',
-      'defaultExpandAll',
-      'datum',
-      'keygen',
-      'multiple',
-      'text',
-      'height',
-      'loading',
-      'onFilter',
-      'filterText',
-      'absolute',
-      'zIndex',
-      'childrenKey',
-      'expandIcons',
-      'emptyText',
-    ].forEach(k => {
-      props[k] = this.props[k]
-    })
+      ;[
+        'treeData',
+        'expanded',
+        'onExpand',
+        'loader',
+        'defaultExpanded',
+        'defaultExpandAll',
+        'datum',
+        'keygen',
+        'multiple',
+        'text',
+        'height',
+        'loading',
+        'onFilter',
+        'filterText',
+        'absolute',
+        'zIndex',
+        'childrenKey',
+        'expandIcons',
+        'emptyText',
+      ].forEach(k => {
+        props[k] = this.props[k]
+      })
     const style = optionWidth && { width: optionWidth }
     props.renderItem = this.renderItem
     return (
@@ -456,29 +466,29 @@ class Select extends PureComponent {
     const { focus, control, position } = this.state
     const { autoAdapt, value, optionWidth } = this.props
     const props = {}
-    ;[
-      'data',
-      'datum',
-      'keygen',
-      'multiple',
-      'columns',
-      'columnWidth',
-      'columnsTitle',
-      'text',
-      'itemsInView',
-      'absolute',
-      'lineHeight',
-      'height',
-      'loading',
-      'onFilter',
-      'filterText',
-      'zIndex',
-      'groupKey',
-      'hideCreateOption',
-      'emptyText',
-    ].forEach(k => {
-      props[k] = this.props[k]
-    })
+      ;[
+        'data',
+        'datum',
+        'keygen',
+        'multiple',
+        'columns',
+        'columnWidth',
+        'columnsTitle',
+        'text',
+        'itemsInView',
+        'absolute',
+        'lineHeight',
+        'height',
+        'loading',
+        'onFilter',
+        'filterText',
+        'zIndex',
+        'groupKey',
+        'hideCreateOption',
+        'emptyText',
+      ].forEach(k => {
+        props[k] = this.props[k]
+      })
 
     const List = props.columns >= 1 || props.columns === -1 ? WrappedBoxList : WrappedOptionList
     const style = optionWidth && { width: optionWidth }
@@ -517,7 +527,6 @@ class Select extends PureComponent {
       placeholder,
       multiple,
       clearable,
-      disabled,
       size,
       onFilter,
       datum,
@@ -535,6 +544,7 @@ class Select extends PureComponent {
       keygen,
       data,
     } = this.props
+    const disabled = this.getDisabledStatus()
     const className = selectClass(
       'inner',
       size,

--- a/test/src/Select/Select.disabled.spec.js
+++ b/test/src/Select/Select.disabled.spec.js
@@ -28,4 +28,41 @@ describe('Select[Disabled]', () => {
       )
     })
   })
+  test('typeof disabled is Boolean True', () => {
+    const disable = true
+    const wrapper = mount(<Select data={['re']} keygen disabled={disable} />)
+    expect(wrapper.find(`.${SO_PREFIX}-input-disabled`).length).toBe(1)
+  })
+  test('typeof disabled is Boolean False', () => {
+    const disable = false
+    const wrapper = mount(<Select data={['re']} keygen disabled={disable} />)
+    expect(wrapper.find(`.${SO_PREFIX}-input-disabled`).length).not.toBe(1)
+  })
+  test('typeof disabled is Function True', () => {
+    const disable = () => true
+    const wrapper = mount(<Select data={['red', 'yello', 'blue']} keygen disabled={disable} />)
+    appendToDOM(wrapper.html())
+    wrapper.find(`.${SO_PREFIX}-select-inner`).simulate('click')
+    const options = wrapper.find(`.${SO_PREFIX}-select-option`)
+    expect(options.length).toBe(3)
+    options.forEach(option => {
+      expect(option.find(`.${SO_PREFIX}-select-disabled`).length).toBe(1)
+    })
+  })
+  test('typeof disabled is Function False', () => {
+    const disable = () => false
+    const wrapper = mount(<Select data={['red', 'yello', 'blue']} keygen disabled={disable} />)
+    appendToDOM(wrapper.html())
+    wrapper.find(`.${SO_PREFIX}-select-inner`).simulate('click')
+    const options = wrapper.find(`.${SO_PREFIX}-select-option`)
+    expect(options.length).toBe(3)
+    options.forEach(option => {
+      expect(option.find(`.${SO_PREFIX}-select-disabled`).length).toBe(0)
+    })
+  })
+  test('typeof disabled is undefiend', () => {
+    const disable = undefined
+    const wrapper = mount(<Select data={['re']} keygen disabled={disable} />)
+    expect(wrapper.find(`.${SO_PREFIX}-input-disabled`).length).not.toBe(1)
+  })
 })


### PR DESCRIPTION
问题描述：
Select组件 disabled 属性接受了非 boolean 值，内部由于未对其进行强制转换，可能导致样式生效，但并不能禁止选择。

处理方式：
Select组件内部增加转换方法对disabled属性进行转换，将外部传入的值进行转换后提供给组件使用。
