### PR TITLE
fix: SelectTree 组件修复属性mode为3，key为数字0时，存在判断歧义，导致不能正确识别为父节点的问题

### DIFF
--- a/src/Datum/Tree.js
+++ b/src/Datum/Tree.js
@@ -93,7 +93,7 @@ export default class {
             const parentChecked = (() => {
               const { path } = this.pathMap.get(id)
               const pid = path[path.length - 1]
-              if (!pid) return false
+              if (!pid && pid !== 0) return false
               return this.valueMap.get(pid) === 1
             })()
             if (!parentChecked) value.push(id)


### PR DESCRIPTION
问题描述：
TreeSelect 组件 mode属性接受值为3的情况下，判断将所选节点整合为公共父节点，当key为数字0时存在判断歧义，导致无法识别为父节点。

解决方案：
针对mode属性为3的情况下，增加判断当key为数字0时，对父节点进行准确过滤。