### PR TITLE
fix: TreeSelect 单选异步加载数据disabled样式不更新问题

### DIFF
--- a/src/Datum/Tree.js
+++ b/src/Datum/Tree.js
@@ -48,6 +48,10 @@ export default class {
     this.setData(data)
   }
 
+  updateDisabled(dis) {
+    this.disabled = dis || (() => false)
+  }
+
   bind(id, update) {
     this.events[id] = update
   }

--- a/src/Tree/Content.js
+++ b/src/Tree/Content.js
@@ -5,6 +5,7 @@ import { PureComponent } from '../component'
 import { treeClass } from './styles'
 import Spin from '../Spin'
 import Checkbox from './Checkbox'
+import { CHANGE_TOPIC } from '../Datum/types'
 
 const loading = (
   <span className={treeClass('icon-loading')}>
@@ -19,6 +20,19 @@ class Content extends PureComponent {
     this.handleNodeClick = this.handleNodeClick.bind(this)
     this.handleNodeExpand = this.handleNodeExpand.bind(this)
     this.handleIndicatorClick = this.handleIndicatorClick.bind(this)
+    this.handleUpdate = this.handleUpdate.bind(this)
+  }
+
+  componentDidMount() {
+    super.componentDidMount()
+    const { datum } = this.props
+    datum.subscribe(CHANGE_TOPIC, this.handleUpdate)
+  }
+
+  componentWillUnmount() {
+    super.componentWillUnmount()
+    const { datum } = this.props
+    datum.unsubscribe(CHANGE_TOPIC, this.handleUpdate)
   }
 
   handleNodeClick() {
@@ -30,6 +44,10 @@ class Content extends PureComponent {
     } else {
       this.props.onNodeClick(data, id)
     }
+  }
+
+  handleUpdate() {
+    this.forceUpdate()
   }
 
   handleNodeExpand() {
@@ -116,6 +134,7 @@ Content.propTypes = {
   fetching: PropTypes.bool,
   doubleClickExpand: PropTypes.bool,
   iconClass: PropTypes.string,
+  datum: PropTypes.object,
 }
 
 export default Content

--- a/src/TreeSelect/datum.js
+++ b/src/TreeSelect/datum.js
@@ -47,7 +47,8 @@ export default function datum(Origin) {
 
     componentDidUpdate(prevProps) {
       if (!shallowEqual(prevProps.data, this.props.data)) {
-        this.datum.setData(this.props.data)
+        this.datum.updateDisabled(this.props.disabled)
+        this.datum.setData(this.props.data, true)
         this.forceUpdate()
       }
     }


### PR DESCRIPTION
1.单选模式异步加载数据后 Content 没有触发更新导致disabled 没有渲染出来
复现地址： https://codesandbox.io/s/treeselect-disabled-update-kuwj0d
解决办法：datum 通过监听changetopic 来更新
2. disabled被缓存无法更新问题