### PR TITLE
fix: SimpleTable data resize lead to misalignment of the header

### DIFF
--- a/src/Table/SimpleTable.js
+++ b/src/Table/SimpleTable.js
@@ -38,6 +38,8 @@ class SimpleTable extends PureComponent {
   componentDidUpdate(prevProps) {
     this.scrollCheck()
     const resize = prevProps.data.length === 0 && this.props.data.length
+    // when resize
+    if (resize && this.body) this.handleScroll({ currentTarget: this.body })
     const shouldResetColgroup = this.props.dataChangeResize && this.props.data !== prevProps.data
     if (resize || shouldResetColgroup || !compareColumns(prevProps.columns, this.props.columns)) {
       this.setState({ colgroup: undefined, resize: true })


### PR DESCRIPTION
问题描述：SimpleTable 当有横向滚动条并且滚动到右边，数据设置为空数组然后请求接口获取并设置数据会导致表头错位
问题原因：这种情况下表头会保持之前的滚动 而导致错位
解决办法：didipdate 后判断是这种情况下重新设置表头滚动距离
复现地址：https://codesandbox.io/s/simpletableqie-huan-shu-ju-hou-gun-dong-cuo-wei-q174sy