### PR TITLE
fix: 修复 Popover 组件在嵌套使用情况下点击空白处无法隐藏所有popover的问题

### DIFF
--- a/site/chunks/Components/Popover.js
+++ b/site/chunks/Components/Popover.js
@@ -59,6 +59,15 @@ const examples = [
     rawText: require('!raw-loader!doc/pages/components/Popover/example-12-content.tsx'),
   },
   {
+    name: '13-nested',
+    title: locate(
+      '嵌套使用 \n 使用多个 Popover 进行嵌套展示',
+      'Nested of Popovers \n Using more than one Popover by nested'
+    ),
+    component: require('doc/pages/components/Popover/example-13-nested.js').default,
+    rawText: require('!raw-loader!doc/pages/components/Popover/example-13-nested.js'),
+  },
+  {
     name: '2-delay',
     title: locate(
       '延迟 \n 可以设置展示延时和关闭延时',

--- a/site/pages/components/Popover/example-13-nested.js
+++ b/site/pages/components/Popover/example-13-nested.js
@@ -1,0 +1,42 @@
+/**
+ * cn - 嵌套使用
+ *    -- 使用多个 Popover 进行嵌套展示
+ * en - Nested of Popovers
+ *    -- Using more than one Popover by nested
+ */
+ import React, { useState } from 'react'
+ import { Button, Popover } from 'shineout'
+ 
+ export default function() {
+   const [show, setshow] = useState(false)
+   const onVisibleChange = v => {
+    setshow(v)
+   }
+   return (
+     <Button>
+       <Popover style={{ padding: '4px 8px' }} trigger="hover" onVisibleChange={onVisibleChange}>
+         <Button>
+           {show && (
+             <Popover.Confirm
+               onCancel={() => {
+                 console.log('cancel')
+               }}
+               onOk={() =>
+                 new Promise(resolve => {
+                   console.log('ok')
+                   setTimeout(() => resolve(true), 2000)
+                 })
+               }
+               text={{ ok: 'Yes', cancel: 'No' }}
+             >
+               Hello Sheinout
+             </Popover.Confirm>
+           )}
+           Nested
+         </Button>
+       </Popover>
+       Hover
+     </Button>
+   )
+ }
+ 

--- a/src/Popover/Panel.js
+++ b/src/Popover/Panel.js
@@ -103,6 +103,15 @@ class Panel extends Component {
         this.setState({ show })
         if (show && this.props.onOpen) this.props.onOpen()
         if (!show && this.props.onClose) this.props.onClose()
+
+        if(show){
+          this.bindScrollDismiss(true)
+          document.addEventListener('mousedown', this.clickAway)
+        }else{
+          this.bindScrollDismiss(false)
+          document.removeEventListener('mousedown', this.clickAway)
+        }
+
       },
       trigger === 'hover' ? delay : 0
     )
@@ -215,8 +224,6 @@ class Panel extends Component {
   handleShow() {
     if (this.delayTimeout) clearTimeout(this.delayTimeout)
     if (this.state.show) return
-    this.bindScrollDismiss(true)
-    document.addEventListener('mousedown', this.clickAway)
     this.setShow(true)
   }
 
@@ -232,8 +239,6 @@ class Panel extends Component {
   handleHide(e) {
     if (e && this.isChildren(e.relatedTarget)) return
     if (this.delayTimeout) clearTimeout(this.delayTimeout)
-    document.removeEventListener('mousedown', this.clickAway)
-    this.bindScrollDismiss(false)
     this.setShow(false)
   }
 


### PR DESCRIPTION
问题描述：
添加/移除监听click事件存在逻辑疏漏。多个Popover组件进行嵌套使用时，点击空白处无法隐藏当前所有的父级嵌套层popover。

解决方案：
调整添加监听click事件的时机。当可视状态为true时重新添加监听，让click事件准确触发。