### PR TITLE
💪 refactor: 修复 Upload.Button 的 prop-types 与 dts 定义不一致的问题

### DIFF
--- a/src/Upload/Progress.js
+++ b/src/Upload/Progress.js
@@ -109,7 +109,7 @@ class Progress extends PureComponent {
 }
 
 Progress.propTypes = {
-  type: PropTypes.oneOf(['primary', 'success', 'info', 'warning', 'error', 'danger']),
+  type: PropTypes.oneOf(['default','primary', 'success', 'info', 'warning', 'error', 'danger']),
   placeholder: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   loading: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   onSuccess: PropTypes.func,

--- a/src/Upload/index.d.ts
+++ b/src/Upload/index.d.ts
@@ -478,7 +478,7 @@ export interface UploadButtonProps<T> extends UploadProps<T> {
    *
    * default: 'primary'
    */
-  type?: 'primary' | 'success' | 'default' | 'warning' | 'danger';
+  type?: 'default' | 'primary' | 'success'| 'info' | 'warning' | 'error' | 'danger';
 
   /**
    * button default content


### PR DESCRIPTION
- prop-types 的定义缺少 default
- dts 的定义缺少 info 、error