### PR TITLE
💪 一些类型系统的 BUG 修正 ， 以及更友好提示的优化

### DIFF
--- a/src/@types/common.d.ts
+++ b/src/@types/common.d.ts
@@ -103,7 +103,7 @@ export interface FormItemStandardProps<Value = any> {
 /**
  * @see https://github.com/Microsoft/TypeScript/issues/29729
  */
-export type LiteralUnion<T extends U, U> = T | (U & {});
+export type LiteralUnion<T extends U, U> = T | (U & Record<never,never>);
 
 export interface ListItemStandardProps<Item = any, Value = any> {
     /**

--- a/src/@types/common.d.ts
+++ b/src/@types/common.d.ts
@@ -104,7 +104,7 @@ export interface FormItemStandardProps<Value = any> {
  * 目前已知的最为简短的写法: @see https://github.com/Microsoft/TypeScript/issues/29729#issuecomment-1082546550
  * 在类型守卫中会存在问题: @see https://github.com/Microsoft/TypeScript/issues/29729#issuecomment-1082791844
  */
- export type LiteralUnion<T extends string | number | symbol> = T | Omit<string,T>
+export type LiteralUnion<T = any> = T extends Record<any, any> ? (keyof T | Omit<string, keyof T>) : T
 
 export interface ListItemStandardProps<Item = any, Value = any> {
     /**
@@ -114,7 +114,7 @@ export interface ListItemStandardProps<Item = any, Value = any> {
      *
      * default: index
      */
-    keygen: LiteralUnion<keyof Item> | ((data: Item) => keyType) | true;
+    keygen: LiteralUnion<Item> | ((data: Item) => keyType) | true;
 
 
     /**
@@ -153,7 +153,7 @@ export interface StructDataStandardProps<Item = any> {
      *
      * default: d => d
      */
-    renderItem?: LiteralUnion<keyof Item> | ((data: Item, index: number) => React.ReactNode);
+    renderItem?: LiteralUnion<Item> | ((data: Item, index: number) => React.ReactNode);
 
     /**
      * The content displayed in the result after selecting, if not set, use renderItem. not show while return null, result is current selected

--- a/src/@types/common.d.ts
+++ b/src/@types/common.d.ts
@@ -101,9 +101,10 @@ export interface FormItemStandardProps<Value = any> {
 }
 
 /**
- * @see https://github.com/Microsoft/TypeScript/issues/29729
+ * 目前已知的最为简短的写法: @see https://github.com/Microsoft/TypeScript/issues/29729#issuecomment-1082546550
+ * 在类型守卫中会存在问题: @see https://github.com/Microsoft/TypeScript/issues/29729#issuecomment-1082791844
  */
-export type LiteralUnion<T extends U, U> = T | (U & Record<never,never>);
+ export type LiteralUnion<T extends string | number | symbol> = T | Omit<string,T>
 
 export interface ListItemStandardProps<Item = any, Value = any> {
     /**
@@ -113,7 +114,7 @@ export interface ListItemStandardProps<Item = any, Value = any> {
      *
      * default: index
      */
-    keygen: LiteralUnion<keyof Item, string | number | symbol> | ((data: Item) => keyType) | true;
+    keygen: LiteralUnion<keyof Item> | ((data: Item) => keyType) | true;
 
 
     /**
@@ -152,7 +153,7 @@ export interface StructDataStandardProps<Item = any> {
      *
      * default: d => d
      */
-    renderItem?: LiteralUnion<keyof Item, string | number | symbol> | ((data: Item, index: number) => React.ReactNode);
+    renderItem?: LiteralUnion<keyof Item> | ((data: Item, index: number) => React.ReactNode);
 
     /**
      * The content displayed in the result after selecting, if not set, use renderItem. not show while return null, result is current selected

--- a/src/@types/common.d.ts
+++ b/src/@types/common.d.ts
@@ -99,6 +99,12 @@ export interface FormItemStandardProps<Value = any> {
        */
       bind?: string[];
 }
+
+/**
+ * @see https://github.com/Microsoft/TypeScript/issues/29729
+ */
+export type LiteralUnion<T extends U, U> = T | (U & {});
+
 export interface ListItemStandardProps<Item = any, Value = any> {
     /**
      * Auxiliary method for generating key. When it is a function, use the return value of this function. When it is a string, use the data value corresponding to this string. For example, 'id' is the same thing as (d) => d.id.
@@ -107,7 +113,7 @@ export interface ListItemStandardProps<Item = any, Value = any> {
      *
      * default: index
      */
-    keygen: ((data: Item) => keyType) | string | true;
+    keygen: LiteralUnion<keyof Item, string | number | symbol> | ((data: Item) => keyType) | true;
 
 
     /**
@@ -146,7 +152,7 @@ export interface StructDataStandardProps<Item = any> {
      *
      * default: d => d
      */
-    renderItem?: ((data: Item, index: number) => React.ReactNode) | string;
+    renderItem?: LiteralUnion<keyof Item, string | number | symbol> | ((data: Item, index: number) => React.ReactNode);
 
     /**
      * The content displayed in the result after selecting, if not set, use renderItem. not show while return null, result is current selected

--- a/src/@types/common.d.ts
+++ b/src/@types/common.d.ts
@@ -104,7 +104,7 @@ export interface FormItemStandardProps<Value = any> {
  * 目前已知的最为简短的写法: @see https://github.com/Microsoft/TypeScript/issues/29729#issuecomment-1082546550
  * 在类型守卫中会存在问题: @see https://github.com/Microsoft/TypeScript/issues/29729#issuecomment-1082791844
  */
-export type LiteralUnion<T = any> = T extends Record<any, any> ? (keyof T | Omit<string, keyof T>) : T
+export type LiteralUnion<T = any> = T extends Record<any, any> ? (keyof T | Omit<string, keyof T>) : never
 
 export interface ListItemStandardProps<Item = any, Value = any> {
     /**

--- a/src/Form/index.d.ts
+++ b/src/Form/index.d.ts
@@ -388,7 +388,7 @@ export interface FormFieldSetProps<Value> {
    *
    * default:
    */
-  empty?: (onInsert: Value) => ReactNode;
+   empty?: (onInsert: (value: Value) => void) => ReactNode;
 
   /**
    * Validation rules


### PR DESCRIPTION
#  🐛 BUG 修正

##  FieldSet

- 应当将 Value 的范型作为 onInsert 的参数， 而不是整个 onInsert

# 💪 类型优化

## common

背景：许多时候，我们的参数主流场景下，希望是 string const type，但是额外总是有一些小场景，我们希望能够支持 string 类型。

- 新增了一个 工具方法 LiteralUnion
- 将 src/@types/common.d.ts 中的 keygen、renderItem 相关的类型进行优化，使用 LiteralUnion
