### PR TITLE
🐛 fix: 修复获取编译阶段配置在某些场景下报错的问题

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,6 +8,7 @@
     },
     "publish": {
       "plugins": [
+        "@babel/plugin-proposal-optional-chaining",
         "@babel/plugin-transform-runtime",
         "@babel/plugin-proposal-class-properties",
         [
@@ -18,13 +19,11 @@
         ]
       ],
       "presets": [
-        ["@babel/preset-env",
+        [
+          "@babel/preset-env",
           {
             "targets": {
-              "browsers": [
-                "last 2 versions",
-                "ie >= 9"
-              ]
+              "browsers": ["last 2 versions", "ie >= 9"]
             },
             "loose": true
           }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@babel/plugin-proposal-class-properties": "^7.1.0",
     "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
     "@babel/plugin-transform-runtime": "^7.14.5",
+    "@babel/plugin-proposal-optional-chaining": "7.17.12",
     "@babel/polyfill": "^7.0.0",
     "@babel/preset-env": "^7.1.6",
     "@babel/preset-react": "^7.0.0",

--- a/src/config.js
+++ b/src/config.js
@@ -4,9 +4,9 @@ import Notification from './utils/notification'
 export const noti = new Notification()
 
 const config = {
-  cssModule: process.env.CSS_MODULE || false,
-  prefix: process.env.SO_PREFIX || 'so',
-  locale: process.env.LOCALE || 'en-US',
+  cssModule: process?.env?.CSS_MODULE || false,
+  prefix: process?.env?.SO_PREFIX || 'so',
+  locale: process?.env?.LOCALE || 'en-US',
   autoSSL: false,
   delay: undefined,
   scrollRatio: 100,


### PR DESCRIPTION
首先 查看 [webpack-define-plugin](https://webpack.js.org/plugins/define-plugin/) ，
通常在 webpack 的配置中，我们为了 避免空对象被整体覆盖我们一般在配置的时候会采用 如下的方式

```js
new webpack.DefinePlugin({
  'process.env.a': 12
});
```

许多的框架内部即使用户使用

```js
new webpack.DefinePlugin({
   process:{
      env:{
         a:12
      }
   }
});
```

框架内部也会使用 `multiLevelObjectToTop` 的方式，使得配置转换为

```js
new webpack.DefinePlugin({
  'process.env.a': 12
});
```

一旦配置被转换成这样，那么实际上代码中是不存在 下面的对象。

```js
{
   process:{
     env:{
     }
   }
}
```
因此一般会报错 ：`process is not defined`.

因此这里取配置应该做容错处理