### PR TITLE
fix: 修复 Form 中 Input 组件设置 trim 并且 delay 为0时，trim失效的问题

### DIFF
--- a/site/chunks/Components/Input.js
+++ b/site/chunks/Components/Input.js
@@ -130,6 +130,15 @@ const examples = [
     component: require('doc/pages/components/Input/example-11-autoSelect.js').default,
     rawText: require('!raw-loader!doc/pages/components/Input/example-11-autoSelect.js'),
   },
+  {
+    name: '12-trim',
+    title: locate(
+      '清除空格 \n trim 为 true 时，失去焦点时会自动删除空白字符。',
+      'Clear space \n When trim is true, blank characters are automatically deleted when lose focus'
+    ),
+    component: require('doc/pages/components/Input/example-12-trim.js').default,
+    rawText: require('!raw-loader!doc/pages/components/Input/example-12-trim.js'),
+  },
 ]
 
 const codes = undefined

--- a/site/pages/components/Input/example-12-trim.js
+++ b/site/pages/components/Input/example-12-trim.js
@@ -1,0 +1,12 @@
+/**
+ * cn - 清除空格
+ *    -- trim 为 true 时，失去焦点时会自动删除空白字符。
+ * en - Clear space
+ *    -- When trim is true, blank characters are automatically deleted when lose focus
+ */
+import React from 'react'
+import { Input } from 'shineout'
+
+export default function() {
+  return <Input placeholder="input something" trim />
+}

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -153,9 +153,8 @@ class Input extends PureComponent {
     const { forceChange, onBlur, clearToUndefined, cancelChange } = this.props
     if (cancelChange) cancelChange()
     const newVal = this.fixValue(value)
-
     const canForceChange = !(clearToUndefined && newVal === '' && this.props.value === undefined)
-    if (canForceChange && !this.invalidNumber(newVal)) forceChange(newVal)
+    if (canForceChange && forceChange && !this.invalidNumber(newVal)) forceChange(newVal)
     if (onBlur) onBlur(e)
   }
 

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -153,12 +153,10 @@ class Input extends PureComponent {
     const { forceChange, onBlur, clearToUndefined, cancelChange } = this.props
     if (cancelChange) cancelChange()
     const newVal = this.fixValue(value)
+
+    const canForceChange = !(clearToUndefined && newVal === '' && this.props.value === undefined)
+    if (canForceChange && !this.invalidNumber(newVal)) forceChange(newVal)
     if (onBlur) onBlur(e)
-    if (this.invalidNumber(newVal)) return
-    if (clearToUndefined && newVal === '' && this.props.value === undefined) {
-      return
-    }
-    if (forceChange) forceChange(newVal)
   }
 
   handleAutoSelect(event) {

--- a/src/hoc/delay.js
+++ b/src/hoc/delay.js
@@ -59,8 +59,6 @@ export default curry(
       }
 
       forceChange(value, ...args) {
-        const { delay } = this.props
-        if (delay === 0) return
         this.setState({ value })
         this.props.onChange(value, ...args)
         this.changeLocked = false

--- a/src/hoc/delay.js
+++ b/src/hoc/delay.js
@@ -59,6 +59,8 @@ export default curry(
       }
 
       forceChange(value, ...args) {
+        const { delay } = this.props
+        if (delay === 0) return
         this.setState({ value })
         this.props.onChange(value, ...args)
         this.changeLocked = false

--- a/test/src/Input/Input.bug.spec.js
+++ b/test/src/Input/Input.bug.spec.js
@@ -1,0 +1,44 @@
+import { Input } from 'shineout'
+import React from 'react'
+import { mount } from 'enzyme'
+
+describe('Input[Trim]', () => {
+  test('should trim', () => {
+    const wrapper = mount(<Input trim />)
+    wrapper.find('input').simulate('change', {
+      target: {
+        value: '    hello',
+      },
+    })
+    wrapper.update()
+    wrapper.find('input').simulate('blur')
+    wrapper.update()
+    expect(wrapper.find('input').prop('value')).toBe('hello')
+  })
+
+  test('should trim • delay', () => {
+    const wrapper = mount(<Input trim delay={500} />)
+    wrapper.find('input').simulate('change', {
+      target: {
+        value: '    hello',
+      },
+    })
+    wrapper.update()
+    wrapper.find('input').simulate('blur')
+    wrapper.update()
+    expect(wrapper.find('input').prop('value')).toBe('hello')
+  })
+
+  test('should trim • delay equal to 0', () => {
+    const wrapper = mount(<Input trim delay={0} />)
+    wrapper.find('input').simulate('change', {
+      target: {
+        value: '    hello',
+      },
+    })
+    wrapper.update()
+    wrapper.find('input').simulate('blur')
+    wrapper.update()
+    expect(wrapper.find('input').prop('value')).toBe('hello')
+  })
+})

--- a/test/src/Input/__snapshots__/example.spec.js.snap
+++ b/test/src/Input/__snapshots__/example.spec.js.snap
@@ -292,3 +292,9 @@ exports[`Snapshot test: Input[site/pages/components/Input/example-11-autoSelect.
   <input />
 </label>
 `;
+
+exports[`Snapshot test: Input[site/pages/components/Input/example-12-trim.js] 1`] = `
+<label>
+  <input />
+</label>
+`;


### PR DESCRIPTION
问题描述：
Form 表单中，Input 组件开启 trim 功能后，同时设置 delay 为 0 的情况下，Input 组件 trim 功能失效。

（废弃）解决方案：
修改  hoc - delay 层 forceChange 方法逻辑。针对 delay 为 0 的情况，做特殊处理，参照 hoc - delay 层 handleChange 方法针对 delay 为 0 时的处理方式。

解决方案：
修改 Input 组件 delay 与 trim 机制，调整 Input 组件 forceChange 触发顺序，保证 onBlur 触发顺序晚于 forceChange。