### PR TITLE
修复 Table treeData 折叠的时候会滚动到顶部的问题

### DIFF
--- a/src/Table/SeperateTable.js
+++ b/src/Table/SeperateTable.js
@@ -271,6 +271,8 @@ class SeperateTable extends PureComponent {
             this.setTop(scrollHeight, fullHeight, 1)
             return
           }
+        } else {
+          return
         }
       }
 


### PR DESCRIPTION
问题描述： Table treeData 折叠的时候Table 会滚动到顶部
解决办法： resetHeight 中 if 判断需要优化