### PR TITLE
fix: 修复 Upload 在 上传错误文件后无法更新 FormItem 状态的问题

### DIFF
--- a/src/Form/inputable.js
+++ b/src/Form/inputable.js
@@ -85,6 +85,7 @@ export default curry(Origin =>
         this.handleError = this.handleError.bind(this)
         this.validate = this.validate.bind(this)
         this.validateHook = this.validateHook.bind(this)
+        this.forceValidate = this.forceValidate.bind(this)
 
         this.lastValue = formDatum && name ? formDatum.get(name) || {} : {}
       }
@@ -272,6 +273,10 @@ export default curry(Origin =>
         if (fieldSetValidate) fieldSetValidate(true)
       }
 
+      forceValidate() {
+        this.validate(this.props.value)
+      }
+
       handleUpdate(value, sn, type) {
         if (type === ERROR_TYPE) {
           if (!isSameError(value, this.state.error)) this.setState({ error: value })
@@ -331,6 +336,7 @@ export default curry(Origin =>
             onChange={this.handleChange}
             onDatumBind={this.handleDatumBind}
             validateHook={this.validateHook}
+            forceValidate={this.forceValidate}
           />
         )
       }

--- a/src/Upload/Upload.js
+++ b/src/Upload/Upload.js
@@ -277,7 +277,9 @@ class Upload extends PureComponent {
       }
     }
     finishedCode = true
-    this.setState({ files })
+    this.setState({ files }, () => {
+      this.updateValidate()
+    })
   }
 
   uploadFile(id, file, data) {

--- a/src/Upload/Upload.js
+++ b/src/Upload/Upload.js
@@ -59,6 +59,7 @@ class Upload extends PureComponent {
     this.removeValue = this.removeValue.bind(this)
     this.recoverValue = this.recoverValue.bind(this)
     this.validatorHandle = this.validatorHandle.bind(this)
+    this.updateValidate = this.updateValidate.bind(this)
     this.useValidator = this.useValidator.bind(this)
     this.handleFileDrop = this.handleFileDrop.bind(this)
     this.handleReplace = this.handleReplace.bind(this)
@@ -121,6 +122,7 @@ class Upload extends PureComponent {
           if (file.status === ERROR && onErrorRemove) {
             onErrorRemove(file.xhr, file.blob, file)
           }
+          this.updateValidate()
         }
       )
     }
@@ -402,8 +404,16 @@ class Upload extends PureComponent {
         if (!draft.files[id]) return
         draft.files[id].status = ERROR
         draft.files[id].message = message
-      })
+      }),
+      () => {
+        this.updateValidate()
+      }
     )
+  }
+
+  updateValidate() {
+    const { forceValidate } = this.props
+    forceValidate()
   }
 
   renderHandle() {
@@ -569,6 +579,7 @@ Upload.propTypes = {
   request: PropTypes.func,
   validateHook: PropTypes.func,
   validator: PropTypes.object,
+  forceValidate: PropTypes.func,
   value: PropTypes.array,
   customResult: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
   style: PropTypes.object,

--- a/src/utils/cleanProps.js
+++ b/src/utils/cleanProps.js
@@ -20,6 +20,7 @@ const names = [
   'autoSelect',
   'autoFix',
   'numType',
+  'forceValidate',
 ]
 
 /**


### PR DESCRIPTION
问题描述：
当 Upload 组件 与 FormItem 组合使用时，Upload 组件上传文件报错后，无法更新 FormItem 的状态。

解决方案：
在 hoc 层增加强制更新方法并交给下层，Upload 组件在上传、移除文件后触发该方法更新 FormItem 状态。