### PR TITLE
fix: 修复 TreeSelect 多选过滤模式下，选中内容后无法继续输入的问题

### DIFF
--- a/src/TreeSelect/Input.js
+++ b/src/TreeSelect/Input.js
@@ -35,7 +35,9 @@ class FilterInput extends Component {
   }
 
   focus() {
-    focusElement.select(this.editElement)
+    requestAnimationFrame(() => {
+      focusElement.select(this.editElement)
+    })
   }
 
   bindElement(el) {


### PR DESCRIPTION
问题描述：
TreeSelect 开启多选和过滤功能后，选择内容后，输入框内呈现伪聚焦现象（有选中效果但并没有focus），无法直接继续输入内容。

解决方法：
为 TreeSelect Input 层 focus 方法增加 requestAnimationFrame 类定时器，参考 Select 组件 Input 层。