### PR TITLE
修复 table empty data 拖动列后报错问题

### DIFF
--- a/src/Table/Thead.js
+++ b/src/Table/Thead.js
@@ -89,7 +89,7 @@ class Thead extends PureComponent {
       const thList = getParent(target, 'tr').children
       const indexInTr = [].indexOf.call(thList, this.resizingTh)
       this.resizingIndex = [].slice.call(thList, 0, indexInTr).reduce((total, th) => {
-        let count = Number(th.getAttribute('colspan')) || 1
+        const count = Number(th.getAttribute('colspan')) || 1
         return total + count
       }, 0)
       this.resizingCol = this.resizingTable.querySelectorAll('col')[this.resizingIndex]
@@ -123,10 +123,11 @@ class Thead extends PureComponent {
     if (col.lastFixed) fixed.push('fixed-last')
 
     const { sorter, onSortChange, data, datum, showSelectAll, disabled, treeColumnsName, treeCheckAll } = this.props
+    const isEmpty = !(data && data.length)
     const align = col.align && `align-${col.align}`
     const ignoreBorderRight = this.rightBorderRecord[col.key] && 'ignore-right-border'
     const resize =
-      level === 0 && columnResizable && col.columnResizable !== false ? (
+      level === 0 && !isEmpty && columnResizable && col.columnResizable !== false ? (
         <span onMouseDown={this.handleMouseDown} className={tableClass('resize-spanner')} />
       ) : null
     if (col.title) {

--- a/test/src/Table/Table.bug.spec.js
+++ b/test/src/Table/Table.bug.spec.js
@@ -1,0 +1,36 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import { Table } from 'shineout'
+import { fetchSync } from 'doc/data/user'
+
+/* global SO_PREFIX */
+
+describe('Table empty data 不能拖动列', () => {
+  const data = fetchSync(20)
+  const columns = [
+    { title: 'id', render: 'id', fixed: 'left', maxWidth: 300, minWidth: 100 },
+    { title: 'Name', render: d => `${d.firstName} ${d.lastName}` },
+    { title: 'Country', render: 'country' },
+    { title: 'Position', render: 'position' },
+    { title: 'Office', render: 'office' },
+    { title: 'Start Date', render: 'start' },
+    {
+      title: 'Salary',
+      render: d => `$${d.salary.toString().replace(/(\d)(?=(\d\d\d)+(?!\d))/g, '$1,')}`,
+    },
+  ]
+  let wrapper
+  beforeAll(() => {
+    wrapper = mount(
+      <Table columnResizable height={300} width={1200} fixed="both" keygen="id" columns={columns} data={[]} />
+    )
+  })
+  test('empty data can not resize', () => {
+    expect(wrapper.find(`table .${SO_PREFIX}-table-resize-spanner`).length).toBe(0)
+  })
+
+  test('data not empty  can resize', () => {
+    wrapper.setProps({ data })
+    expect(wrapper.find(`table .${SO_PREFIX}-table-resize-spanner`).length).toBe(7)
+  })
+})


### PR DESCRIPTION
问题原因： empty data 的时候还没有计算列宽
解决办法：empty data 不可以拖到列