### PR TITLE
fix: 修复 select 在开启 compressed 与 multiple 功能时选项可能无法展示的问题

### DIFF
--- a/src/Select/More.js
+++ b/src/Select/More.js
@@ -57,7 +57,7 @@ export function getResetMore(onFilter, container, doms) {
     }
   }
   // at least show one
-  if (num === 0 && itemWidthArr[0] && itemWidthArr[0] > 70) {
+  if (num === 0 && itemWidthArr[0]) {
     num = 1
   }
   return num


### PR DESCRIPTION
问题描述：
 Select 组件在开启 折叠选项与多选的情况下，选择单条数据后可能会导致选中项无法展示。

解决方案：
取消选对单个中项的标签长度限制，内部不再处理小标签（70px）的情况。