### PR TITLE
Fix bug datepicker range style

### DIFF
--- a/src/DatePicker/Container.js
+++ b/src/DatePicker/Container.js
@@ -275,7 +275,6 @@ class Container extends PureComponent {
     const mode = this.props.type
     const { disabledMap } = this
     const isRange = index !== undefined
-    const { min, max, range, disabled, disabledTime } = this.props
 
     switch (mode) {
       case 'time':
@@ -289,10 +288,9 @@ class Container extends PureComponent {
       case 'month':
         return isRange ? disabledMap.month[index](date) : disabledMap.month(date)
       case 'datetime':
-        return (
-          ParamFns.handleDisabled(date, min, max, range, disabled, disabledTime) ||
-          (isRange ? disabledMap.day[index](date) : disabledMap.day(date))
-        )
+        return isRange
+          ? disabledMap.time[index](date, undefined, undefined, true) || disabledMap.day[index](date)
+          : disabledMap.time(date, undefined, undefined, true) || disabledMap.day(date)
       default:
         return false
     }

--- a/src/DatePicker/Day.js
+++ b/src/DatePicker/Day.js
@@ -315,7 +315,7 @@ Day.propTypes = {
   onChangeSync: PropTypes.func,
   onDayHover: PropTypes.func,
   onModeChange: PropTypes.func.isRequired,
-  range: PropTypes.number,
+  range: PropTypes.oneOfType([PropTypes.number, PropTypes.bool]),
   rangeDate: PropTypes.array,
   rangeTemp: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   showTimePicker: PropTypes.bool,

--- a/src/DatePicker/Day.js
+++ b/src/DatePicker/Day.js
@@ -198,7 +198,7 @@ class Day extends PureComponent {
       classList.push(utils.isSameDay(date, rangeDate[index]) && 'active')
 
       hoverClass = datepickerClass(
-        utils.compareAsc(rangeDate[0], date) <= 0 && utils.compareAsc(rangeDate[1], date) >= 0 && 'hover',
+        utils.compareDay(rangeDate[0], date) <= 0 && utils.compareDay(rangeDate[1], date) >= 0 && 'hover',
         // Datetime Picker range end datetime classname #330
         utils.isSameDay(rangeDate[index], date) && `hover-${index === 0 ? 'start' : 'end'} active`
       )

--- a/src/DatePicker/Time.js
+++ b/src/DatePicker/Time.js
@@ -174,7 +174,7 @@ Time.propTypes = {
   min: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   max: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   onChange: PropTypes.func.isRequired,
-  range: PropTypes.number,
+  range: PropTypes.oneOfType([PropTypes.number, PropTypes.bool]),
   value: PropTypes.object,
   defaultTime: PropTypes.array,
   index: PropTypes.number,

--- a/src/DatePicker/TimeScroll.js
+++ b/src/DatePicker/TimeScroll.js
@@ -136,7 +136,7 @@ TimeScroll.propTypes = {
   disabled: PropTypes.func,
   min: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   max: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
-  range: PropTypes.number,
+  range: PropTypes.oneOfType([PropTypes.number, PropTypes.bool]),
   current: PropTypes.object,
   mode: PropTypes.string,
   disabledTime: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),

--- a/src/DatePicker/paramUtils.js
+++ b/src/DatePicker/paramUtils.js
@@ -44,7 +44,7 @@ function handleDisabled(...args) {
 }
 
 function judgeTimeByRange(...args) {
-  const [target, value, mode, min, max, range, disabled, disabledTime, test] = args
+  const [target, value, mode, min, max, range, disabled, disabledTime] = args
   const date = new Date(value.getTime())
   switch (mode) {
     case 'H':
@@ -78,7 +78,7 @@ function judgeTimeByRange(...args) {
     default:
       break
   }
-  const isDisabled = handleDisabled(date, min, max, range, disabled, disabledTime, test)
+  const isDisabled = handleDisabled(date, min, max, range, disabled, disabledTime)
   return [isDisabled, date]
 }
 

--- a/src/DatePicker/utils.js
+++ b/src/DatePicker/utils.js
@@ -195,6 +195,13 @@ function toDateWithFormat(dirtyDate, fmt, def) {
   return date
 }
 
+function compareDay(dateLeft, dateRight) {
+  if (!dateLeft || !dateRight) return NaN
+  const left = new Date(dateLeft.getFullYear(), dateLeft.getMonth(), dateLeft.getDate())
+  const right = new Date(dateRight.getFullYear(), dateRight.getMonth(), dateRight.getDate())
+  return compareAsc(left, right)
+}
+
 function compareMonth(dateLeft, dateRight, pad = 0) {
   if (!dateLeft || !dateRight) return 0
   const left = new Date(dateLeft.getFullYear(), dateLeft.getMonth(), 1)
@@ -284,6 +291,7 @@ export default {
   cloneTime,
   compareAsc,
   compareMonth,
+  compareDay,
   getDaysOfMonth,
   format: formatted,
   isInvalid,


### PR DESCRIPTION
问题描述：
DatePicker 在开启 range 模式下，设置了 defaultTime 可能会导致选中范围的样式失效。

解决方案：
在对比是否为范围内的逻辑中去除 time ，仅对比年月日。