### PR TITLE
修复 TreeSelect unmatch 无法删除问题

### DIFF
--- a/src/Datum/Tree.js
+++ b/src/Datum/Tree.js
@@ -61,6 +61,7 @@ export default class {
   }
 
   setUnmatedValue() {
+    this.unmatchedValueMap = new Map()
     if (!this.value || !this.data) return
     this.value.forEach(v => {
       const data = this.getDataById(v)
@@ -68,6 +69,11 @@ export default class {
       if (unmatched) this.unmatchedValueMap.set(v, true)
       else this.unmatchedValueMap.delete(v)
     })
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  isUnMatch(data) {
+    return data && data[IS_NOT_MATCHED_VALUE]
   }
 
   setValue(value) {

--- a/src/Datum/Tree.js
+++ b/src/Datum/Tree.js
@@ -65,7 +65,7 @@ export default class {
     if (!this.value || !this.data) return
     this.value.forEach(v => {
       const data = this.getDataById(v)
-      const unmatched = data && data[IS_NOT_MATCHED_VALUE]
+      const unmatched = this.isUnMatch(data)
       if (unmatched) this.unmatchedValueMap.set(v, true)
       else this.unmatchedValueMap.delete(v)
     })

--- a/src/TreeSelect/TreeSelect.js
+++ b/src/TreeSelect/TreeSelect.js
@@ -188,7 +188,8 @@ export default class TreeSelect extends PureComponent {
 
   handleRemove(data) {
     const { datum } = this.props
-    datum.set(datum.getKey(data), 0)
+    const dataKey = data && datum.isUnMatch(data) ? data.value : datum.getKey(data)
+    datum.set(dataKey, 0)
     this.handleChange(data, datum.getKey(data))
   }
 


### PR DESCRIPTION
问题描述：TreeSelect 对于unmatch 的数据无法进行删除
问题原因： 内部逻辑对于unmatch 删除 有遗漏
解决办法： 增加对unmatch 的value 的 删除逻辑