### PR TITLE
fixed: 修复在 mode 为 4 的模式下，删除异常的问题、修复异步 data 问题

### DIFF
--- a/src/Datum/Tree.js
+++ b/src/Datum/Tree.js
@@ -129,11 +129,16 @@ export default class {
     // self
     if (!this.isDisabled(id)) this.setValueMap(id, checked)
 
+    const data = this.getDataById(id)
+
     if (CheckedMode.Freedom === this.mode) {
       // Free mode will return zero
+      if (this.isUnMatch(data)) {
+        this.unmatchedValueMap.set(id, checked)
+      }
       return 0
     }
-    const data = this.getDataById(id)
+
     if (data && data[IS_NOT_MATCHED_VALUE]) {
       if (checked) this.unmatchedValueMap.set(id, true)
       else this.unmatchedValueMap.delete(id)

--- a/src/Datum/Tree.js
+++ b/src/Datum/Tree.js
@@ -131,18 +131,15 @@ export default class {
 
     const data = this.getDataById(id)
 
-    if (CheckedMode.Freedom === this.mode) {
-      // Free mode will return zero
-      if (this.isUnMatch(data)) {
-        this.unmatchedValueMap.set(id, checked)
-      }
-      return 0
-    }
-
     if (data && data[IS_NOT_MATCHED_VALUE]) {
       if (checked) this.unmatchedValueMap.set(id, true)
       else this.unmatchedValueMap.delete(id)
       return null
+    }
+
+    if (CheckedMode.Freedom === this.mode) {
+      // Free mode will return zero
+      return 0
     }
 
     const { path, children } = this.pathMap.get(id)

--- a/src/TreeSelect/filter.js
+++ b/src/TreeSelect/filter.js
@@ -50,15 +50,11 @@ export default Origin =>
         let res = noCache ? undefined : this.resultCache.get(v)
         if (!res) {
           res = datum.getDataById(v)
-          if (res && !noCache) this.resultCache.set(v, res)
+          if (res && !noCache && !res[IS_NOT_MATCHED_VALUE]) this.resultCache.set(v, res)
           else if (!res) res = { [IS_NOT_MATCHED_VALUE]: true, value: v }
         }
         if (res) {
-          const newRes = datum.dataMap.get(res.value)
-          if (newRes) {
-            this.resultCache.set(v, newRes)
-            result.push(newRes)
-          } else result.push(res)
+          result.push(res)
         }
       })
       return result

--- a/src/TreeSelect/filter.js
+++ b/src/TreeSelect/filter.js
@@ -54,7 +54,11 @@ export default Origin =>
           else if (!res) res = { [IS_NOT_MATCHED_VALUE]: true, value: v }
         }
         if (res) {
-          result.push(res)
+          const newRes = datum.dataMap.get(res.value)
+          if (newRes) {
+            this.resultCache.set(v, newRes)
+            result.push(newRes)
+          } else result.push(res)
         }
       })
       return result


### PR DESCRIPTION
问题描述：
1、TreeSelect 在开启 unmatch 且 mode 为 4 的情况下，删除 unmatch 项可能存在异常。
2、TreeSelect 在开启 unmatch 且 data 异步的情况下，value 会先被当作 unmatch 项，data 更新后未更新 value unmatch 状态。

解决方案：
1、在删除时增加对 mode 为 4 情况下的处理。
2、在 data 更新后，更新 value 的 unmatch 状态。