### PR TITLE
优化 tab 滚动

### DIFF
--- a/src/Tabs/Header.js
+++ b/src/Tabs/Header.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import immer from 'immer'
+import { addResizeObserver } from 'shineout/utils/dom/element'
 import { PureComponent } from '../component'
 import Button from '../Button'
 import icons from '../icons'
@@ -28,17 +29,26 @@ class Header extends PureComponent {
     this.handleNextClick = this.handleMove.bind(this, false)
     this.moveToCenter = this.moveToCenter.bind(this)
     this.handleCollapse = this.handleCollapse.bind(this)
+    this.handleResize = this.handleResize.bind(this)
   }
 
   componentDidMount() {
     super.componentDidMount()
     const { isVertical } = this.props
     this.setPosition(isVertical)
+    this.removeObserver = addResizeObserver(this.innerElement, this.handleResize, { direction: true, timer: 100 })
   }
 
   componentDidUpdate() {
     const { isVertical } = this.props
     this.setPosition(isVertical)
+  }
+
+  componentWillUnmount() {
+    super.componentWillUnmount()
+    if (this.removeObserver) {
+      this.removeObserver()
+    }
   }
 
   setPosition(isVertical) {
@@ -48,6 +58,12 @@ class Header extends PureComponent {
     const scrollAttribute = this.scrollElement[`client${attributeString}`]
     const { attribute: domAttribute } = this.state
     this.setState({ overflow: scrollAttribute > domAttribute + innerAttribute, attributeString })
+  }
+
+  handleResize(entry, { x, y }) {
+    const { isVertical } = this.props
+    const isResize = isVertical ? y : x
+    if (isResize) this.setPosition(isVertical)
   }
 
   bindElement(name, el) {
@@ -61,6 +77,7 @@ class Header extends PureComponent {
     let attribute = a + (lt ? -innerAttribute : innerAttribute)
     if (attribute < 0) attribute = 0
     if (attribute + innerAttribute > scrollAttribute) attribute = scrollAttribute - innerAttribute
+    if (scrollAttribute <= innerAttribute) attribute = 0
     this.setState({ attribute })
   }
 

--- a/src/Tabs/styles/tabs.less
+++ b/src/Tabs/styles/tabs.less
@@ -328,25 +328,29 @@
   }
 
   &-dash {
-    .@{tabs-prefix}-tab {
-      border-color: transparent;
-      background: transparent;
-      color: inherit;
-    }
-    .@{tabs-prefix}-active {
-      color: @tabs-line-active-color;
-      border-color: transparent;
-      background: transparent;
-      &:after {
-        bottom: 0;
-        left: 50%;
-        transform: translateX(-50%);
-        position: absolute;
-        width: 24px;
-        height: 3px;
-        border-radius: 3px;
-        background: @tabs-line-active-color;
-        content: ' ';
+    > .@{tabs-prefix}-header {
+      .@{tabs-prefix}-tab {
+        border-color: transparent;
+        background: transparent;
+        color: inherit;
+      }
+
+      .@{tabs-prefix}-active {
+        color: @tabs-line-active-color;
+        border-color: transparent;
+        background: transparent;
+
+        &:after {
+          bottom: 0;
+          left: 50%;
+          transform: translateX(-50%);
+          position: absolute;
+          width: 24px;
+          height: 3px;
+          border-radius: 3px;
+          background: @tabs-line-active-color;
+          content: ' ';
+        }
       }
     }
   }

--- a/src/utils/func.js
+++ b/src/utils/func.js
@@ -47,3 +47,23 @@ export function createFunc(func) {
   if (typeof func === 'function') return func
   return data => (func ? data[func] : data)
 }
+
+export const throttle = function(func, timer) {
+  const that = {}
+  const cleanTimer = () => {
+    if (that.timer) {
+      clearTimeout(that.timer)
+      that.timer = ''
+    }
+  }
+  if (!timer) return [func, cleanTimer]
+  return [
+    (...args) => {
+      cleanTimer()
+      that.timer = setTimeout(() => {
+        func(...args)
+      }, timer)
+    },
+    cleanTimer,
+  ]
+}


### PR DESCRIPTION
1. 修复：当滚动到最后， 然后放大页面， 再点击左边的箭头， tab 会滚动到最右边的问题
2. 修复：当容器宽度变化的时候右边的箭头没有更新