### PR TITLE
fixed: 修复 value 更新后表格更新异常的问题

### DIFF
--- a/src/Table/Tr.js
+++ b/src/Table/Tr.js
@@ -171,7 +171,7 @@ class Tr extends Component {
       ...reset
     } = this.props
     const other = Object.keys(reset)
-      .filter(key => !['format', 'prediction', 'value', 'onChange'].includes(key))
+      .filter(key => !['format', 'prediction', 'onChange'].includes(key))
       .reduce((r, key) => ({ ...r, [key]: reset[key] }), {})
     const tds = []
     let skip = 0


### PR DESCRIPTION
问题描述：
Table 在 value 动态更新后，表格内容可能存在更新异常。

问题原因：
透传属性 value 在性能优化中被过滤，导致无法触发更新。

解决方案：
放开 value 允许向下透传。