### PR TITLE
fixed: 修复 Select 默认情况下允许输入的问题

### DIFF
--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -560,6 +560,7 @@ class Select extends PureComponent {
       keygen,
       convertBr,
       data,
+      onFilter,
     } = this.props
     const disabled = this.getDisabledStatus()
     const className = selectClass(
@@ -591,7 +592,7 @@ class Select extends PureComponent {
           onClear={clearable ? this.handleClear : undefined}
           onCreate={onCreate}
           onRemove={this.handleRemove}
-          onFilter={this.handleFilter}
+          onFilter={onFilter && this.handleFilter}
           datum={datum}
           disabled={disabled}
           focus={this.state.focus}

--- a/test/src/Carousel/__snapshots__/example.spec.js.snap
+++ b/test/src/Carousel/__snapshots__/example.spec.js.snap
@@ -7,7 +7,9 @@ exports[`Carousel[snapshot] Snapshot test: Carousel[site/pages/components/Carous
     <div>
       <div>
         <div>
-          <span />
+          <span>
+            slide
+          </span>
           <a>
             <svg>
               <path />
@@ -25,7 +27,9 @@ exports[`Carousel[snapshot] Snapshot test: Carousel[site/pages/components/Carous
     <div>
       <div>
         <div>
-          <span />
+          <span>
+            center
+          </span>
           <a>
             <svg>
               <path />
@@ -43,7 +47,9 @@ exports[`Carousel[snapshot] Snapshot test: Carousel[site/pages/components/Carous
     <div>
       <div>
         <div>
-          <span />
+          <span>
+            circle
+          </span>
           <a>
             <svg>
               <path />

--- a/test/src/Dropdown/__snapshots__/example.spec.js.snap
+++ b/test/src/Dropdown/__snapshots__/example.spec.js.snap
@@ -903,7 +903,9 @@ exports[`Dropdown[snapshot] Snapshot test: Dropdown[site/pages/components/Dropdo
     <div>
       <div>
         <div>
-          <span />
+          <span>
+            primary
+          </span>
           <a>
             <svg>
               <path />
@@ -923,7 +925,9 @@ exports[`Dropdown[snapshot] Snapshot test: Dropdown[site/pages/components/Dropdo
     <div>
       <div>
         <div>
-          <span />
+          <span>
+            default
+          </span>
           <a>
             <svg>
               <path />

--- a/test/src/Form/__snapshots__/Form.spec.js.snap
+++ b/test/src/Form/__snapshots__/Form.spec.js.snap
@@ -1018,7 +1018,9 @@ exports[`Form[snapshot] Snapshot test: Form[site/pages/components/Form/example-1
       <div>
         <div>
           <div>
-            <span />
+            <span>
+              green
+            </span>
             <a>
               <svg>
                 <path />

--- a/test/src/Message/__snapshots__/Message.spec.js.snap
+++ b/test/src/Message/__snapshots__/Message.spec.js.snap
@@ -56,7 +56,9 @@ exports[`Message[snapshot] Snapshot test: Message[site/pages/components/Message/
   <div>
     <div>
       <div>
-        <span />
+        <span>
+          top-right
+        </span>
         <a>
           <svg>
             <path />


### PR DESCRIPTION
问题描述：
组件内部判断逻辑存在异常，导致Select 在默认情况下允许用户键入文本，键入行为不会导致其它后续操作。

解决方案：
调整判断逻辑，根据实际情况调整 inputable 功能的开启条件。