### PR TITLE
feat: 修复 Table 组件 loading 属性类型错误

### DIFF
--- a/src/hoc/pagable.js
+++ b/src/hoc/pagable.js
@@ -15,7 +15,7 @@ export default function (Component) {
   return class extends PureComponent {
     static propTypes = {
       data: PropTypes.any,
-      loading: PropTypes.bool,
+      loading: PropTypes.oneOfType([PropTypes.bool, PropTypes.node]),
       pagination: PropTypes.object.isRequired,
     }
 
@@ -43,7 +43,7 @@ export default function (Component) {
           current: this.getProp('current'),
           pageSize: this.getProp('pageSize'),
           total,
-          disabled: loading,
+          disabled: !!loading,
         },
         pagination,
         { onChange: this.handleChange },


### PR DESCRIPTION
问题描述：
Table 组件 loading 内部属性定义存在错误，开启分页功能后，添加自定义 loading 属性导致报错。

解决方案：
调整内部属性定义，转换属性类型向下传递。