### PR TITLE
fixed: 修复 Select onFilter 无法输入的问题

### DIFF
--- a/src/Select/Input.js
+++ b/src/Select/Input.js
@@ -203,14 +203,18 @@ class FilterInput extends Component {
       onCompositionStart: this.handleCompositionStart,
       onCompositionEnd: this.handleCompositionEnd,
     }
-
     if (isValidElement(value)) {
+      if (value.type.toString() === 'Symbol(react.fragment)') {
+        return cloneElement(<span>{value}</span>, {
+          ...props,
+          suppressContentEditableWarning: true,
+        })
+      }
       return cloneElement(value, {
         ...props,
         suppressContentEditableWarning: true,
       })
     }
-
     return <span dangerouslySetInnerHTML={{ __html: value }} {...props} onPaste={this.handlePaste} />
   }
 }


### PR DESCRIPTION
问题描述：
Select 组件 在开启 onFilter 后，renderItem 传递 Fragment 会导致无法继续输入内容。

解决方案：
针对 renderItem 返回值为 Fragment 情况作特殊处理，内部为其添加 span 进行包裹（参照 string 返回值的处理方式）。