### PR TITLE
fix: 修复 Upload 在 Form.Item 中校验信息逻辑 bug

### DIFF
--- a/site/pages/components/Upload/test-001-tip.tsx
+++ b/site/pages/components/Upload/test-001-tip.tsx
@@ -11,6 +11,7 @@ export default () => (
   <Form>
     <Form.Item tip="hello world">
       <Upload
+        rules={[{ required: true, message: '想啥呢，你没传文件！' }]}
         action="/upload-test"
         accept="image/*"
         name="file"
@@ -32,6 +33,10 @@ export default () => (
           Upload file
         </Button>
       </Upload>
+    </Form.Item>
+    <Form.Item>
+      <Form.Submit>Submit</Form.Submit>
+      <Form.Reset>Reset</Form.Reset>
     </Form.Item>
   </Form>
 )

--- a/src/Form/Item.js
+++ b/src/Form/Item.js
@@ -119,10 +119,11 @@ class Item extends Component {
   }
 
   renderHelp(errors) {
-    if (errors.length > 0) {
+    const realErrors = errors.filter(e => e.message)
+    if (realErrors.length > 0) {
       return (
         <div className={formClass('error')}>
-          {errors.map((e, i) => (
+          {realErrors.map((e, i) => (
             <div key={i}>{e.message}</div>
           ))}
         </div>
@@ -196,6 +197,6 @@ Item.defaultProps = {
 export default Item
 
 // eslint-disable-next-line
-export const itemConsumer = Origin => (props) => {
+export const itemConsumer = Origin => props => {
   return <Consumer>{events => <Origin {...props} {...events} />}</Consumer>
 }

--- a/src/Form/inputable.js
+++ b/src/Form/inputable.js
@@ -86,7 +86,6 @@ export default curry(Origin =>
         this.handleError = this.handleError.bind(this)
         this.validate = this.validate.bind(this)
         this.validateHook = this.validateHook.bind(this)
-        this.forceValidate = this.forceValidate.bind(this)
 
         this.lastValue = formDatum && name ? formDatum.get(name) || {} : {}
       }
@@ -274,10 +273,6 @@ export default curry(Origin =>
         if (fieldSetValidate) fieldSetValidate(true)
       }
 
-      forceValidate() {
-        this.validate(this.props.value)
-      }
-
       handleUpdate(value, sn, type) {
         if (type === ERROR_TYPE) {
           if (!isSameError(value, this.state.error)) this.setState({ error: value })
@@ -338,7 +333,6 @@ export default curry(Origin =>
             onChange={this.handleChange}
             onDatumBind={this.handleDatumBind}
             validateHook={this.validateHook}
-            forceValidate={this.forceValidate}
           />
         )
       }

--- a/src/Upload/Upload.js
+++ b/src/Upload/Upload.js
@@ -59,7 +59,6 @@ class Upload extends PureComponent {
     this.removeValue = this.removeValue.bind(this)
     this.recoverValue = this.recoverValue.bind(this)
     this.validatorHandle = this.validatorHandle.bind(this)
-    this.updateValidate = this.updateValidate.bind(this)
     this.useValidator = this.useValidator.bind(this)
     this.handleFileDrop = this.handleFileDrop.bind(this)
     this.handleReplace = this.handleReplace.bind(this)
@@ -124,7 +123,6 @@ class Upload extends PureComponent {
           if (file.status === ERROR && onErrorRemove) {
             onErrorRemove(file.xhr, file.blob, file)
           }
-          this.updateValidate()
         }
       )
     }
@@ -279,9 +277,7 @@ class Upload extends PureComponent {
       }
     }
     finishedCode = true
-    this.setState({ files }, () => {
-      this.updateValidate()
-    })
+    this.setState({ files })
   }
 
   uploadFile(id, file, data) {
@@ -408,16 +404,8 @@ class Upload extends PureComponent {
         if (!draft.files[id]) return
         draft.files[id].status = ERROR
         draft.files[id].message = message
-      }),
-      () => {
-        this.updateValidate()
-      }
+      })
     )
-  }
-
-  updateValidate() {
-    const { forceValidate } = this.props
-    forceValidate()
   }
 
   renderHandle() {
@@ -584,7 +572,6 @@ Upload.propTypes = {
   request: PropTypes.func,
   validateHook: PropTypes.func,
   validator: PropTypes.object,
-  forceValidate: PropTypes.func,
   value: PropTypes.array,
   customResult: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
   style: PropTypes.object,

--- a/src/utils/cleanProps.js
+++ b/src/utils/cleanProps.js
@@ -20,7 +20,6 @@ const names = [
   'autoSelect',
   'autoFix',
   'numType',
-  'forceValidate',
 ]
 
 /**


### PR DESCRIPTION
问题描述：
Upload 在 Form.Item 中使用时，使用 onError 属性时可能存在报错问题；
Upload 在上传成功时，可能存在报错问题；
上述问题在历史修复中曾调整过校验逻辑，详见：
https://github.com/sheinsight/shineout/commit/68fce515200100447bf4c3c5d89b1568be13de63

解决方案：
调整 Upload 上传校验逻辑，优化同表单联动时的校验规则，恢复历史调整中的部分逻辑。