### PR TITLE
fix: 开启google translate后，Jumper Input报错

### DIFF
--- a/src/Pagination/Jumper.js
+++ b/src/Pagination/Jumper.js
@@ -6,6 +6,8 @@ import Input from '../Input'
 import { getDirectionClass } from '../utils/classname'
 
 const inputStyle = { width: 60, display: 'inline-block' }
+const inheritStyle = { color: 'inherit' }
+
 const nofunc = () => {}
 
 class Jumper extends PureComponent {
@@ -61,7 +63,7 @@ class Jumper extends PureComponent {
 
     return (
       <div className={paginationClass(getDirectionClass('section'))}>
-        {txt[0]}
+        <span style={inheritStyle}>{txt[0]}</span>
         <Input
           key={this.renderRequire}
           value={current}
@@ -75,7 +77,7 @@ class Jumper extends PureComponent {
           className={paginationClass(isSimple && 'simple-input')}
           delay={400}
         />
-        {txt[1]}
+        <span style={inheritStyle}>{txt[1]}</span>
       </div>
     )
   }


### PR DESCRIPTION
当开启google translate，在跳转框中输入页码进行跳转，页面报错

原因参考： https://github.com/facebook/react/issues/11538#issuecomment-390386520

![image](https://user-images.githubusercontent.com/8273654/203500732-0a70a5e1-c861-4faf-bd7f-e9c27049a138.png)
