### PR TITLE
fixed: 修复 Table 拖拽列在某些情况下可能存在报错的问题

### DIFF
--- a/src/Table/resizable.js
+++ b/src/Table/resizable.js
@@ -45,6 +45,8 @@ export default Table =>
     }
 
     handleResize(index, width, colgroup) {
+      if (colgroup === undefined) return
+
       const { onColumnResize } = this.props
       const changed = immer(this.state, draft => {
         const column = draft.columns[index]


### PR DESCRIPTION
问题描述：
https://github.com/sheinsight/shineout/issues/1858

表格宽度缓存 colgroup 临时置空（用于触发列宽重计算）时，可能会导致在两次执行 resize 过程间出现取值异常。

解决方案：
处理置空情况，仅在 colgroup 重计算完成后触发 resize。