### PR TITLE
fixed: 修复 Table 在配置 Sticky 具体属性后可能导致表头渲染异常的问题

### DIFF
--- a/cypress/e2e/Table/bug.table.sticky.cy.ts
+++ b/cypress/e2e/Table/bug.table.sticky.cy.ts
@@ -1,0 +1,33 @@
+describe('Table[sticky]', () => {
+  it('修复 Table 在配置 Sticky 具体属性后可能导致表头渲染异常的问题', () => {
+    cy.visit('/cn/components/Table?example=test-003-sticky')
+    cy.get('.so-table')
+      .first()
+      .as('Table')
+    cy.get('.doc-example-body .so-button')
+      .first()
+      .as('Button')
+
+    cy.get('@Button').click()
+
+    // 检查表头初始化时，是否存在宽度和偏移量
+    cy.get('@Table')
+      .children()
+      .first()
+      .children()
+      .should('not.have.css', 'width', '0px')
+      .should('not.have.css', 'left', '0px')
+
+    // 滚动窗口，触发表头附着
+    cy.scrollTo(0, 500)
+
+    // 检查表头滚动后，是否存在宽度和偏移量
+    cy.get('@Table')
+      .children()
+      .first()
+      .children()
+      .should('have.css', 'position', 'fixed')
+      .should('not.have.css', 'width', '0px')
+      .should('not.have.css', 'left', '0px')
+  })
+})

--- a/site/chunks/Components/Table.js
+++ b/site/chunks/Components/Table.js
@@ -559,6 +559,19 @@ const examples = [
     parseTsText: require('!raw-loader!ts-loader!doc/pages/components/Table/test-002-value.tsx'),
 
   },
+  {
+    name: 'test-003-sticky',
+    isTs: true,
+    isTest: true,
+    title: locate(
+      'T:sticky \n fixed: 修复 Table 在配置 Sticky 具体属性后可能导致表头渲染异常的问题 \n https://github.com/sheinsight/shineout/pull/1890',
+      'T:sticky \n '
+    ),
+    component: require('doc/pages/components/Table/test-003-sticky.tsx').default,
+    rawText: require('!raw-loader!doc/pages/components/Table/test-003-sticky.tsx'),
+    parseTsText: require('!raw-loader!ts-loader!doc/pages/components/Table/test-003-sticky.tsx'),
+
+  },
 ]
 
 const codes = undefined

--- a/site/pages/components/Table/test-003-sticky.tsx
+++ b/site/pages/components/Table/test-003-sticky.tsx
@@ -1,0 +1,55 @@
+/**
+ * cn - T:sticky
+ *    -- fixed: 修复 Table 在配置 Sticky 具体属性后可能导致表头渲染异常的问题
+ *    -- https://github.com/sheinsight/shineout/pull/1890
+ * en - T:sticky
+ *    --
+ */
+import React, { useState } from 'react'
+import { Table, Button, TYPE } from 'shineout'
+import { fetchSync } from 'doc/data/user'
+
+interface TableRowData {
+  id: number
+  time: string
+  start: string
+  height: number
+  salary: number
+  office: string
+  country: string
+  office5: string
+  position: string
+  lastName: string
+  firstName: string
+}
+
+type TableColumnItem = TYPE.Table.ColumnItem<TableRowData>
+
+const data: TableRowData[] = fetchSync(20)
+
+const columns: TableColumnItem[] = [
+  { title: 'id', render: 'id', width: 50 },
+  { title: 'Name', render: d => `${d.firstName} ${d.lastName}` },
+  { title: 'Country', render: 'country' },
+  { title: 'Position', render: 'position' },
+  { title: 'Office', render: 'office' },
+  { title: 'Start Date', render: 'start' },
+  {
+    title: 'Salary',
+    render: d => `$${d.salary.toString().replace(/(\d)(?=(\d\d\d)+(?!\d))/g, '$1,')}`,
+  },
+]
+
+const App: React.FC = () => {
+  const [show, setShow] = useState(false)
+  return (
+    <div>
+      <Button onClick={() => setShow(!show)}>Show</Button>
+      <div style={{ display: show ? 'block' : 'none' }}>
+        <Table sticky={{ top: 10 }} data={data} columns={columns} keygen="id" />
+      </div>
+    </div>
+  )
+}
+
+export default App

--- a/src/Sticky/index.js
+++ b/src/Sticky/index.js
@@ -84,7 +84,7 @@ class Sticky extends PureComponent {
     const selfRect = copyBoundingClientRect(this.element)
 
     // If the element is hidden, the width and height will be 0
-    if (selfRect.width === 0 && selfRect.height === 0) return
+    if (selfRect && selfRect.width === 0 && selfRect.height === 0) return
 
     const { marginBottom, marginTop } = getComputedStyle(this.element)
     selfRect.height += parseFloat(marginBottom) + parseFloat(marginTop)

--- a/src/Sticky/index.js
+++ b/src/Sticky/index.js
@@ -82,6 +82,10 @@ class Sticky extends PureComponent {
     if (needResetPostion === false) return
 
     const selfRect = copyBoundingClientRect(this.element)
+
+    // If the element is hidden, the width and height will be 0
+    if (selfRect.width === 0 && selfRect.height === 0) return
+
     const { marginBottom, marginTop } = getComputedStyle(this.element)
     selfRect.height += parseFloat(marginBottom) + parseFloat(marginTop)
     const scrollElement = this.targetElement || document.body


### PR DESCRIPTION
问题描述：
Table 在配置 Sticky 具体属性如 top:10 后，当父元素 display none 时，可能获取无效的样式计算数值。

解决方案：
对计算样式数值进行判断，当样式计算数值为无效值时，不设置默认样式。