### PR TITLE
fixed: 修复开启 onChange 后 List 布局可能异常的问题

### DIFF
--- a/src/DataList/List.tsx
+++ b/src/DataList/List.tsx
@@ -97,6 +97,19 @@ class Index<U, T> extends Component<BaseListProps<U, T>> {
   renderItem(value: U, index: number) {
     const { keygen, onChange } = this.props
     const haveRowSelected = isFunc(onChange)
+
+    if (haveRowSelected) {
+      return (
+        <div
+          className={this.getItemClassName(value, index, haveRowSelected)}
+          key={getKey(value, keygen, index) as React.Key}
+        >
+          {this.renderCheckBox(haveRowSelected, value, index)}
+          <div className={listClass('item-meta')}>{this.getContent(value, index)}</div>
+        </div>
+      )
+    }
+
     return (
       <div
         className={this.getItemClassName(value, index, haveRowSelected)}

--- a/src/DataList/styles/list.less
+++ b/src/DataList/styles/list.less
@@ -55,7 +55,7 @@
 
     &.@{list-prefix}-checkbox {
       display: flex;
-      justify-content: space-between;
+      justify-content: flex-start;
       align-items: center;
       .@{list-prefix}-item-meta {
         flex: 1;

--- a/src/DataList/styles/list.less
+++ b/src/DataList/styles/list.less
@@ -27,7 +27,6 @@
   }
 }
 
-
 .@{list-prefix}-container {
   box-sizing: border-box;
   position: relative;
@@ -45,7 +44,7 @@
     padding: @list-default-padding;
 
     &:not(:last-child)::after {
-      content: "";
+      content: '';
       position: absolute;
       bottom: 0px;
       left: 0;
@@ -56,12 +55,15 @@
 
     &.@{list-prefix}-checkbox {
       display: flex;
-      justify-content: flex-start;
+      justify-content: space-between;
       align-items: center;
+      .@{list-prefix}-item-meta {
+        flex: 1;
+      }
     }
 
     .@{list-prefix}-meta-container,
-    .@{list-prefix}-meta.@{list-prefix}-includes{
+    .@{list-prefix}-meta.@{list-prefix}-includes {
       box-sizing: border-box;
       display: flex;
       justify-content: flex-start;
@@ -83,7 +85,6 @@
       box-sizing: border-box;
       padding-top: 12px;
     }
-
   }
 
   &.@{list-prefix}-fixed {
@@ -111,18 +112,16 @@
     flex: 1;
   }
 
-
   &.@{list-prefix}-bordered {
     border: @list-item-bottom-border-width solid @gray-200;
     border-radius: 4px;
   }
 
-
-  .@{list-prefix}-footer{
+  .@{list-prefix}-footer {
     position: relative;
 
     &::before {
-      content: "";
+      content: '';
       position: absolute;
       top: 0px;
       left: 0;
@@ -131,7 +130,6 @@
       background-color: @gray-200;
     }
   }
-
 
   .@{list-prefix}-loading {
     position: absolute;
@@ -164,8 +162,12 @@
   }
 
   .@{button-prefix} + .@{button-prefix} {
-    &:not(@{button-prefix}-rtl) {margin-left: 0;}
-    &.@{button-prefix}-rtl {margin-right: 0;}
+    &:not(@{button-prefix}-rtl) {
+      margin-left: 0;
+    }
+    &.@{button-prefix}-rtl {
+      margin-right: 0;
+    }
   }
 }
 
@@ -174,7 +176,7 @@
     padding: @list-small-padding;
 
     .@{list-prefix}-meta-container,
-    .@{list-prefix}-meta.@{list-prefix}-includes{
+    .@{list-prefix}-meta.@{list-prefix}-includes {
       .@{list-prefix}-meta-avatar {
         width: @list-small-avatar;
         height: @list-small-avatar;
@@ -196,7 +198,6 @@
     }
   }
 }
-
 
 .@{list-prefix}-container.@{list-prefix}-rtl {
   direction: rtl;

--- a/test/src/DataList/list.spec.js
+++ b/test/src/DataList/list.spec.js
@@ -135,6 +135,15 @@ describe('List[onChange]', () => {
     expect(handleChange).toBeCalled()
     expect(handleChange.mock.calls[0][0][0]).toBe(data[0])
   })
+
+  test('onChange style', () => {
+    const handleChange = jest.fn()
+    const wrapper = mount(
+      <List keygen="id" data={data} onChange={handleChange} renderItem={d => <div>{d.firstName + d.lastName}</div>} />
+    )
+
+    expect(wrapper.find(`.${SO_PREFIX}-list-item-meta`).length).toBe(3)
+  })
 })
 
 describe('List[rowClassName]', () => {


### PR DESCRIPTION
问题描述：
List 在开启 onChange 属性后，其下每个 item 项布局为 flex 。renderItem 所渲染的容器并未占满整个剩余空间，可能导致布局向前锁进的问题。

解决方案：
组件内部添加容器包裹，将容器设置为占满空间。