### PR TITLE
fixed: 修复 List 在 onChange 情况下，布局可能异常的问题

### DIFF
--- a/src/DataList/List.js
+++ b/src/DataList/List.js
@@ -80,6 +80,16 @@ class Index extends Component {
   renderItem(value, index) {
     const { keygen, onChange } = this.props
     const haveRowSelected = isFunc(onChange)
+
+    if (haveRowSelected) {
+      return (
+        <div className={this.getItemClassName(value, index, haveRowSelected)} key={getKey(value, keygen, index)}>
+          {this.renderCheckBox(haveRowSelected, value, index)}
+          <div className={listClass('item-meta')}>{this.getContent(value, index)}</div>
+        </div>
+      )
+    }
+
     return (
       <div className={this.getItemClassName(value, index, haveRowSelected)} key={getKey(value, keygen, index)}>
         {this.renderCheckBox(haveRowSelected, value, index)}

--- a/src/DataList/List.js
+++ b/src/DataList/List.js
@@ -81,19 +81,12 @@ class Index extends Component {
     const { keygen, onChange } = this.props
     const haveRowSelected = isFunc(onChange)
 
-    if (haveRowSelected) {
-      return (
-        <div className={this.getItemClassName(value, index, haveRowSelected)} key={getKey(value, keygen, index)}>
-          {this.renderCheckBox(haveRowSelected, value, index)}
-          <div className={listClass('item-meta')}>{this.getContent(value, index)}</div>
-        </div>
-      )
-    }
+    const content = this.getContent(value, index)
 
     return (
       <div className={this.getItemClassName(value, index, haveRowSelected)} key={getKey(value, keygen, index)}>
         {this.renderCheckBox(haveRowSelected, value, index)}
-        {this.getContent(value, index)}
+        {haveRowSelected ? <div className={listClass('item-meta')}>{content}</div> : content}
       </div>
     )
   }

--- a/src/DataList/styles/list.less
+++ b/src/DataList/styles/list.less
@@ -58,6 +58,10 @@
       display: flex;
       justify-content: flex-start;
       align-items: center;
+      
+      .@{list-prefix}-item-meta {
+        flex: 1;
+      }
     }
 
     .@{list-prefix}-meta-container,

--- a/test/src/DataList/list.spec.js
+++ b/test/src/DataList/list.spec.js
@@ -135,6 +135,15 @@ describe('List[onChange]', () => {
     expect(handleChange).toBeCalled()
     expect(handleChange.mock.calls[0][0][0]).toBe(data[0])
   })
+
+  test('onChange style', () => {
+    const handleChange = jest.fn()
+    const wrapper = mount(
+      <List keygen="id" data={data} onChange={handleChange} renderItem={d => <div>{d.firstName + d.lastName}</div>} />
+    )
+
+    expect(wrapper.find(`.${SO_PREFIX}-list-item-meta`).length).toBe(3)
+  })
 })
 
 describe('List[rowClassName]', () => {


### PR DESCRIPTION
问题描述：
List 在开启 onChange 属性后，其下每个 item 项布局为 flex 。renderItem 所渲染的容器并未占满整个剩余空间，可能导致布局向前锁进的问题。

解决方案：
组件内部添加容器包裹，将容器设置为占满空间。