### PR TITLE
fix: 修复 querySelector id 不能以数字开头的问题

### DIFF
--- a/src/utils/uid.js
+++ b/src/utils/uid.js
@@ -1,14 +1,8 @@
 import { v4 as getUUid } from 'uuid'
 
-let uid = Date.now()
-
-export function getUid() {
-  uid += 1
-  return uid
-}
-
 export function getUidStr(...args) {
-  return getUUid(...args)
+  // dom id  cannot start with number
+  return `a${getUUid(...args)}`
 }
 
 function $getKey(d, gen, index) {

--- a/test/utils/uid.spec.js
+++ b/test/utils/uid.spec.js
@@ -4,6 +4,9 @@ describe('uid.js[getUid-getUidStr]', () => {
   test('should getUidStr return different', () => {
     expect(getUidStr()).not.toBe(getUidStr())
   })
+  test('should return d when gen is true', () => {
+    expect(() => document.querySelector(`#${getUidStr()}`)).not.toThrow()
+  })
 })
 
 describe('uid.js[getKey]', () => {


### PR DESCRIPTION
问题原因： querySelect中的id 不能以数字开头，新的 uid 是以数字开头的