### PR TITLE
修复： Datepicker 时间范围选择器 range 传number 并且设置 max 或者 min 后 禁用的逻辑错误，导致无法选择…

### DIFF
--- a/cypress/e2e/DatePicker/test.datepicker.timerange.cy.ts
+++ b/cypress/e2e/DatePicker/test.datepicker.timerange.cy.ts
@@ -1,0 +1,19 @@
+import { open } from "./common"
+
+
+describe('DatePicker[timerange]', () => {
+  it('should set time zone', () => {
+    cy.visit('/cn/components/DatePicker?example=test-002-time-range-max')
+    cy.get('.so-datepicker').as('DataPicker')
+    open('@DataPicker')
+    cy.get('@DataPicker').find('.so-datepicker-time-picker').setAttr({style: 'visibility: visible; z-index: 100'})
+    cy.get('@DataPicker').find('.so-datepicker-datetime').eq(0).as('TimePicker0')
+    cy.get('@DataPicker').find('.so-datepicker-datetime').eq(1).as('TimePicker1')
+    // pokcer0
+    cy.get('@TimePicker0').find('.so-datepicker-time-list').eq(0).find('span').eq(1).click()
+    cy.get('@TimePicker0').find('.so-datepicker-time-picker + span').should("have.text", "01:00:00")
+    // pokcer0
+    cy.get('@TimePicker1').find('.so-datepicker-time-list').eq(0).find('span').eq(2).click()
+    cy.get('@TimePicker1').find('.so-datepicker-time-picker + span').should("have.text", "00:00:00")
+  })
+})

--- a/site/chunks/Components/DatePicker.js
+++ b/site/chunks/Components/DatePicker.js
@@ -389,6 +389,19 @@ const examples = [
     parseTsText: require('!raw-loader!ts-loader!doc/pages/components/DatePicker/test-001-control.tsx'),
 
   },
+  {
+    name: 'test-002-time-range-max',
+    isTs: true,
+    isTest: true,
+    title: locate(
+      'timepicker range max \n timepicker max 和 range 一起使用导致禁用逻辑错误',
+      ''
+    ),
+    component: require('doc/pages/components/DatePicker/test-002-time-range-max.tsx').default,
+    rawText: require('!raw-loader!doc/pages/components/DatePicker/test-002-time-range-max.tsx'),
+    parseTsText: require('!raw-loader!ts-loader!doc/pages/components/DatePicker/test-002-time-range-max.tsx'),
+
+  },
 ]
 
 const codes = undefined

--- a/site/pages/components/DatePicker/test-002-time-range-max.tsx
+++ b/site/pages/components/DatePicker/test-002-time-range-max.tsx
@@ -1,0 +1,22 @@
+/**
+ * cn - timepicker range max
+ *    -- timepicker max 和 range 一起使用导致禁用逻辑错误
+ */
+import React from 'react'
+import { DatePicker } from 'shineout'
+
+const date = new Date('2022/02/24 23:59:59')
+
+const App = () => (
+  <div>
+    <DatePicker
+      type="datetime"
+      defaultValue={['2022-02-17 00:00:00', '2022-02-24 00:00:00']}
+      range={7 * 24 * 3600}
+      style={{ marginTop: '12px' }}
+      placeholder="Select datetime"
+      max={date}
+    />
+  </div>
+)
+export default App

--- a/src/DatePicker/Time.js
+++ b/src/DatePicker/Time.js
@@ -40,9 +40,9 @@ class Time extends PureComponent {
   }
 
   handleDisabled(value, val, mode, onlyVaild) {
-    const { disabled, min, max, range, disabledTime } = this.props
-    const [isDisabled, date] = paramUtils.judgeTimeByRange(
-      val,
+    const { disabled, min, max, range, disabledTime, index, rangeDate } = this.props
+    const [isDisabled, date] = paramUtils.judgeTimeByRange({
+      target: val,
       value,
       mode,
       min,
@@ -50,8 +50,10 @@ class Time extends PureComponent {
       range,
       disabled,
       disabledTime,
-      this.getOptions()
-    )
+      index,
+      rangeDate,
+      options: this.getOptions(),
+    })
     return onlyVaild ? isDisabled : [isDisabled, date]
   }
 
@@ -75,7 +77,7 @@ class Time extends PureComponent {
   }
 
   renderTimeScroller(value, min, max, hours) {
-    const { format, hourStep, minuteStep, secondStep, range, disabled, disabledTime } = this.props
+    const { format, hourStep, minuteStep, secondStep, range, disabled, disabledTime, index, rangeDate } = this.props
 
     const rtl = isRTL()
     let res = [
@@ -93,6 +95,8 @@ class Time extends PureComponent {
           step={hourStep}
           onChange={this.handleHourChange}
           disabledTime={disabledTime}
+          index={index}
+          rangeDate={rangeDate}
         />
       ),
       format.indexOf('h') >= 0 && (
@@ -109,6 +113,8 @@ class Time extends PureComponent {
           step={hourStep}
           onChange={this.handleHourChange}
           disabledTime={disabledTime}
+          index={index}
+          rangeDate={rangeDate}
         />
       ),
       format.indexOf('m') >= 0 && (
@@ -124,6 +130,8 @@ class Time extends PureComponent {
           step={minuteStep}
           onChange={this.handleMinuteChange}
           disabledTime={disabledTime}
+          index={index}
+          rangeDate={rangeDate}
         />
       ),
       format.indexOf('s') >= 0 && (
@@ -139,6 +147,8 @@ class Time extends PureComponent {
           step={secondStep}
           onChange={this.handleSecondChange}
           disabledTime={disabledTime}
+          index={index}
+          rangeDate={rangeDate}
         />
       ),
       /a|A/.test(format) && (
@@ -155,6 +165,8 @@ class Time extends PureComponent {
           ampm
           onChange={this.handleAMPMChange}
           disabledTime={disabledTime}
+          index={index}
+          rangeDate={rangeDate}
         />
       ),
     ]
@@ -200,6 +212,7 @@ Time.propTypes = {
   disabledTime: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   disabledRegister: PropTypes.func,
   timeZone: PropTypes.string,
+  rangeDate: PropTypes.array,
 }
 
 export default Time

--- a/src/DatePicker/TimeScroll.js
+++ b/src/DatePicker/TimeScroll.js
@@ -91,7 +91,21 @@ class TimeScroll extends PureComponent {
   }
 
   renderItem(num) {
-    const { ampm, total, value, step, mode, min, max, range: ra, current, disabled, disabledTime } = this.props
+    const {
+      ampm,
+      total,
+      value,
+      step,
+      mode,
+      min,
+      max,
+      range: ra,
+      current,
+      disabled,
+      disabledTime,
+      index,
+      rangeDate,
+    } = this.props
 
     if (typeof step === 'number' && step <= 0) return null
     if (!ampm && typeof step === 'number' && num % step !== 0) return null
@@ -101,17 +115,19 @@ class TimeScroll extends PureComponent {
     else if (total === 12 && num === 0) text = '12'
     else if (num < 10) text = `0${num}`
 
-    const [isDisabled] = paramUtils.judgeTimeByRange(
-      num,
-      current,
+    const [isDisabled] = paramUtils.judgeTimeByRange({
+      target: num,
+      value: current,
       mode,
       min,
       max,
-      ra,
+      range: ra,
       disabled,
       disabledTime,
-      this.getOptions()
-    )
+      options: this.getOptions(),
+      index,
+      rangeDate,
+    })
 
     const className = datepickerClass(!isDisabled && value === num && 'time-active')
     return (
@@ -157,6 +173,8 @@ TimeScroll.propTypes = {
   mode: PropTypes.string,
   disabledTime: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   timeZone: PropTypes.string,
+  index: PropTypes.number,
+  rangeDate: PropTypes.array,
 }
 
 TimeScroll.defaultProps = {

--- a/src/DatePicker/paramUtils.js
+++ b/src/DatePicker/paramUtils.js
@@ -1,7 +1,6 @@
 import utils from './utils'
-import { isNumber } from '../utils/is'
 
-const { TIME_FORMAT, compareAsc, addSeconds, format } = utils
+const { TIME_FORMAT, compareAsc, format } = utils
 
 const handleOnChangeParams = type => (date, change, blur = undefined, isEnd = undefined, isQuickSelect = undefined) => [
   date,
@@ -26,25 +25,28 @@ function handleTimeDisabled(date, disabledTime, options) {
   return undefined
 }
 
-function handleDisabled(...args) {
-  const [date, min, max, range, disabled, disabledTime, options] = args
+function handleDisabled(params) {
+  const { date, min, max, range, disabled, disabledTime, options, index, rangeDate } = params
   let isDisabled
   if (disabled) isDisabled = disabled(date)
   if (disabledTime) isDisabled = isDisabled || handleTimeDisabled(date, disabledTime)
   if (isDisabled) return true
   if (!isDisabled && min) {
     if (compareAsc(date, min) < 0) return true
-    if (range && isNumber(range) && compareAsc(date, addSeconds(min, range, options)) > 0) return true
   }
   if (!isDisabled && max) {
     if (compareAsc(date, max) > 0) return true
-    if (range && isNumber(range) && compareAsc(date, addSeconds(max, -range, options)) < 0) return true
+  }
+  if (!isDisabled && index === 1 && rangeDate && rangeDate[0]) {
+    if (typeof range === 'number' && utils.compareAsc(date, utils.addSeconds(rangeDate[0], range, options)) > 0) {
+      return true
+    }
   }
   return false
 }
 
-function judgeTimeByRange(...args) {
-  const [target, value, mode, min, max, range, disabled, disabledTime, options] = args
+function judgeTimeByRange(params) {
+  const { target, value, mode, min, max, range, disabled, disabledTime, index, rangeDate, options } = params
   let date = new Date(value.getTime())
   switch (mode) {
     case 'H':
@@ -79,7 +81,17 @@ function judgeTimeByRange(...args) {
       break
   }
 
-  const isDisabled = handleDisabled(date, min, max, range, disabled, disabledTime, options)
+  const isDisabled = handleDisabled({
+    date,
+    min,
+    max,
+    range,
+    disabled,
+    disabledTime,
+    options,
+    index,
+    rangeDate,
+  })
   return [isDisabled, date]
 }
 


### PR DESCRIPTION
修复： Datepicker 时间范围选择器 range 传number 并且设置 max 或者 min 后 禁用的逻辑错误，导致无法选择的问题。