### PR TITLE
fix: 2.x cascader filter 时候动态变化数据后选择会报错的问题

### DIFF
--- a/src/Cascader/Cascader.tsx
+++ b/src/Cascader/Cascader.tsx
@@ -150,8 +150,8 @@ class Cascader<DataItem, Value extends CascaderBaseValue> extends PureComponent<
   componentDidUpdate(prevProps: OriginCascaderProps<DataItem, Value>, prevState: State<Value>) {
     this.datum.mode = this.props.mode
     this.setOpenEvent()
-    const { onFilter, filterDataChange, filterText } = this.props
-    if (!filterDataChange && prevProps.data !== this.props.data) this.datum.setData(this.props.data, true)
+    const { onFilter, filterText } = this.props
+    if (prevProps.sourceData !== this.props.sourceData) this.datum.setData(this.props.sourceData, true)
     if (prevProps.value !== this.props.value) {
       this.datum.setValue(this.props.value || (([] as unknown) as Value))
       this.updatePathByValue()

--- a/src/Cascader/Props.ts
+++ b/src/Cascader/Props.ts
@@ -57,7 +57,7 @@ export interface FilterProps<DataItem> extends Pick<TreeDatumOptions<DataItem>, 
 
 export type GetFilterProps<Props, DataItem> = Omit<
   Props,
-  'filterText' | 'filterDataChange' | 'firstMatchNode' | 'onFilter' | 'childrenKey'
+  'filterText' | 'filterDataChange' | 'firstMatchNode' | 'onFilter' | 'childrenKey' | 'sourceData'
 > &
   Pick<FilterProps<DataItem>, 'onFilter' | 'childrenKey' | 'filterDelay'>
 
@@ -66,6 +66,10 @@ export interface OriginCascaderProps<DataItem, Value extends CascaderBaseValue>
     Pick<InputTitleProps, 'innerTitle'>,
     Pick<TreeDatumOptions<DataItem>, 'mode'>,
     Pick<StandardProps, 'style'> {
+  /**
+   * @inner 源数据
+   */
+  sourceData?: DataItem[]
   /**
    * @en Form field, used with Form
    * @cn 表单字段, 配合 Form 使用

--- a/src/Cascader/filter.tsx
+++ b/src/Cascader/filter.tsx
@@ -65,6 +65,7 @@ export default <DataItem, Props>(Origin: React.ComponentType<Props>) =>
         <Origin
           {...(this.props as unknown) as Props}
           data={data}
+          sourceData={this.props.data}
           filterText={filterText}
           onFilter={this.handleFilter}
           filterDataChange={filter}


### PR DESCRIPTION
问题原因 筛选的时候 data 更新不会触发 datum.setData 导致