### PR TITLE
fix: 2.x absoluteList 增加 element 存在检测

### DIFF
--- a/site/pages/documentation/changelog/2.x.x.md
+++ b/site/pages/documentation/changelog/2.x.x.md
@@ -1,5 +1,6 @@
 # 更新日志
 ### 2.0.3
+- 修复 AbsoluteList 在下拉列表不存在或被移除导致报错的问题(< 2.0.3)
 - 修复 Input.Number 在失焦时触发的 onChange 会变成string类型的问题(< 2.0.3)
 - 修复 Button 在设置 href 属性后设置 target 属性无效的错误 (< 2.0.3)
 - 修复 Cascader 在 filter 时候动态变化数据后选择会报错的问题 (< 2.0.3)

--- a/src/AnimationList/AbsoluteList.tsx
+++ b/src/AnimationList/AbsoluteList.tsx
@@ -15,15 +15,24 @@ import { AbsoluteProps, GetAbsoluteProps } from './Props'
 
 const PICKER_V_MARGIN = 4
 let root: HTMLDivElement
-function initRoot() {
+
+function initRoot(element?: HTMLElement) {
   const defaultContainer = getDefaultContainer()
   root = document.createElement('div')
   root.className = listClass('root', isRTL() && 'rtl')
   defaultContainer.appendChild(root)
+
+  if (element && isInDocument(element) === false) {
+    root.appendChild(element)
+  }
 }
 
-function getRoot() {
-  if (!root || isInDocument(root) === false) initRoot()
+function getRoot(element?: HTMLElement) {
+  if (!root || isInDocument(root) === false) initRoot(element)
+
+  if (element && isInDocument(element) === false) {
+    root.appendChild(element)
+  }
   return root
 }
 
@@ -33,7 +42,7 @@ const listPosition = ['drop-down', 'drop-up']
 const pickerPosition = ['left-bottom', 'left-top', 'right-bottom', 'right-top']
 const dropdownPosition = ['bottom-left', 'bottom-right', 'top-left', 'top-right']
 
-export default function<U extends {}>(List: ComponentType<U>) {
+export default function <U extends {}>(List: ComponentType<U>) {
   class AbsoluteList extends Component<AbsoluteProps> {
     state = {
       overdoc: false,
@@ -60,7 +69,7 @@ export default function<U extends {}>(List: ComponentType<U>) {
       this.lastStyle = {}
 
       if (!root) initRoot()
-      this.container = typeof this.props.absolute === 'function' ? this.props.absolute() : getRoot()
+      this.container = this.getContainer()
       this.element = document.createElement('div')
       if (this.container) this.container.appendChild(this.element)
       if (props.getResetPosition) {
@@ -71,7 +80,7 @@ export default function<U extends {}>(List: ComponentType<U>) {
 
     componentDidMount() {
       if (this.props.absolute && !this.container) {
-        this.container = typeof this.props.absolute === 'function' ? this.props.absolute() : getRoot()
+        this.container = this.getContainer()
         this.container.appendChild(this.element)
         if (this.props.focus) {
           this.forceUpdate()
@@ -99,6 +108,10 @@ export default function<U extends {}>(List: ComponentType<U>) {
       }
     }
 
+    getContainer(element?: HTMLElement) {
+      return typeof this.props.absolute === 'function' ? this.props.absolute() : getRoot(element)
+    }
+
     getPosition(rect: DOMRect) {
       const { fixed } = this.props
       let { position } = this.props as { position: string }
@@ -121,8 +134,7 @@ export default function<U extends {}>(List: ComponentType<U>) {
       if (rtl) {
         position = getRTLPosition(position)
       }
-
-      const { container } = this
+      const container = this.getContainer(this.element)
       const defaultContainer = getDefaultContainer()
       const rootContainer = container === getRoot() || !container ? defaultContainer : container
       const containerRect = rootContainer.getBoundingClientRect()


### PR DESCRIPTION
问题描述：
AbsoluteList 涉及的组件，在下拉列表被删除或因其他原因导致 dom 移除的情况下组件报错。
AbsoluteList 列表在初次渲染时会在顶层挂在 so-root-list 顶层容器，用于统一存放开启 absolute 属性组件的下拉列表。该行为在组件初始化过程中完成。

解决方案：
在打开 AbsoluteList 时对列表元素做 dom 检测，并保证展开列表存在于 document 中。

备注：
该方案可能会做调整，最终方案参考后续正式版。