### PR TITLE
chore: add repository info

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "module": "./es/index.js",
   "typings": "./lib/index.d.ts",
   "author": "lobos841@gmail.com",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sheinsight/shineout.git"
+  },
   "license": "MIT",
   "scripts": {
     "test": "cross-env NODE_ENV=test jest --config jest.config.js",


### PR DESCRIPTION
I find it difficult to accurately navigate from the NPMJS official website to the corresponding GitHub repository

 so I believe it is necessary