### PR TITLE
fix: 修复 Slider 在 value 为 0 且范围包含0 的情况下，无法滑动到 0 位置的问题

### DIFF
--- a/src/Slider/Container.tsx
+++ b/src/Slider/Container.tsx
@@ -39,7 +39,10 @@ class Container<Value extends number | number[]> extends PureComponent<Container
   getValue() {
     const { range, value, scale = DefaultValue.scale } = this.props
     const from = scale[0]
-    if (!range) return value || from
+    if (!range) {
+      if (value === 0) return value
+      return value || from
+    }
 
     let val: number | number[] | undefined = value
     if (range && !isArray(value)) val = [from, from]


### PR DESCRIPTION
问题描述：滑动范围包含 0 的情况下，比如从 -1 到 1，滑块从 1 往左滑无法经停 0，直接滑去 -1