### PR TITLE
Fix split method to subtract column ratio instead of column width

### DIFF
--- a/src/utils/numbers.ts
+++ b/src/utils/numbers.ts
@@ -15,7 +15,7 @@ export function split(total: number, nums: number[]) {
   const ratios = nums.map(n => {
     if (n) {
       const r = n / total
-      remain -= n
+      remain -= r
       return r
     }
     nilCount += 1


### PR DESCRIPTION
Fixes #2075

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sheinsight/shineout/pull/2162?shareId=39dbf1ba-292c-4ad8-9d0a-5f9702d36f7b).