### PR TITLE
chore: release v2.0.31

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shineout",
-  "version": "2.0.31-beta.8",
+  "version": "2.0.31",
   "description": "Shein 前端组件库",
   "main": "./lib/index.js",
   "module": "./es/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 
 import * as utils from './utils'
 
-export default { utils, version: '2.0.31-beta.8' }
+export default { utils, version: '2.0.31' }
 export { utils }
 export { setLocale } from './locale'
 export { color, style } from './utils/expose'


### PR DESCRIPTION
版本号从 2.0.31-beta.8 升级为 2.0.31