### PR TITLE
fix: 修复 Table 使用 treeExpandKeys 时 data 含不可序列化字段导致页面崩溃的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shineout",
-  "version": "2.0.31",
+  "version": "2.0.32-beta.1",
   "description": "Shein 前端组件库",
   "main": "./lib/index.js",
   "module": "./es/index.js",

--- a/site/chunks/Components/Table.js
+++ b/site/chunks/Components/Table.js
@@ -572,6 +572,19 @@ const examples = [
     parseTsText: require('!raw-loader!doc/pages/components/Table/test-003-sticky.tsx'),
 
   },
+  {
+    name: 'test-004-tree-expand-mutate',
+    isTs: true,
+    isTest: true,
+    title: locate(
+      'T:tree-expand-mutate \n fixed: 修复 Table treeExpandKeys 在 data 包含不可序列化字段（DOM 节点、React ref）时报循环引用错误 \n 验证直接修改 data 引用后 Table 仍能正常响应式更新',
+      'T:tree-expand-mutate \n '
+    ),
+    component: require('doc/pages/components/Table/test-004-tree-expand-mutate.tsx').default,
+    rawText: require('!raw-loader!doc/pages/components/Table/test-004-tree-expand-mutate.tsx'),
+    parseTsText: require('!raw-loader!doc/pages/components/Table/test-004-tree-expand-mutate.tsx'),
+
+  },
 ]
 
 const codes = undefined

--- a/site/pages/components/Table/test-004-tree-expand-mutate.tsx
+++ b/site/pages/components/Table/test-004-tree-expand-mutate.tsx
@@ -1,0 +1,116 @@
+/**
+ * cn - T:tree-expand-mutate
+ *    -- fixed: 修复 Table treeExpandKeys 在 data 包含不可序列化字段（DOM 节点、React ref）时报循环引用错误
+ *    -- 验证直接修改 data 引用后 Table 仍能正常响应式更新
+ * en - T:tree-expand-mutate
+ *    --
+ */
+import React, { useState, useRef, useEffect } from 'react'
+import { Table, Button, TYPE } from 'shineout'
+
+interface TreeRowData {
+  id: number
+  name: string
+  // 模拟用户 data 中存储了 DOM 节点引用（会导致循环引用）
+  bindElement?: HTMLElement | null
+  children?: TreeRowData[]
+}
+
+type TableColumnItem = TYPE.Table.ColumnItem<TreeRowData>
+
+const columns: TableColumnItem[] = [
+  {
+    title: 'ID',
+    render: 'id',
+    width: 80,
+    treeColumnsName: 'children',
+    treeIndent: 20,
+  },
+  { title: 'Name', render: 'name' },
+  {
+    title: 'Element',
+    render: d => (d.bindElement ? 'has DOM ref' : '-'),
+  },
+]
+
+const App: React.FC = () => {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [data, setData] = useState<TreeRowData[]>([
+    {
+      id: 1,
+      name: 'Parent 1',
+      children: [
+        { id: 11, name: 'Child 1-1' },
+        { id: 12, name: 'Child 1-2' },
+      ],
+    },
+    {
+      id: 2,
+      name: 'Parent 2',
+      children: [
+        { id: 21, name: 'Child 2-1' },
+        { id: 22, name: 'Child 2-2', children: [{ id: 221, name: 'Child 2-2-1' }] },
+      ],
+    },
+    {
+      id: 3,
+      name: 'Parent 3',
+    },
+  ])
+  const [expandKeys, setExpandKeys] = useState<(number | string)[]>([1])
+
+  // 模拟用户在 data 中绑定 DOM 节点（渲染后 DOM 节点上有 __reactFiber$ 循环引用）
+  useEffect(() => {
+    if (containerRef.current) {
+      setData(prev => {
+        const next = [...prev]
+        next[0] = { ...next[0], bindElement: containerRef.current }
+        return next
+      })
+    }
+  }, [])
+
+  const handleMutateData = () => {
+    const newData = [...data]
+    newData[0] = { ...newData[0], name: `Parent 1 (updated ${Date.now()})` }
+    setData(newData)
+  }
+
+  const handleAddChild = () => {
+    const newData = [...data]
+    const parent = { ...newData[1] }
+    parent.children = [...(parent.children || []), { id: Date.now(), name: `New Child ${Date.now()}` }]
+    newData[1] = parent
+    setData(newData)
+    if (!expandKeys.includes(2)) {
+      setExpandKeys([...expandKeys, 2])
+    }
+  }
+
+  return (
+    <div ref={containerRef}>
+      <div style={{ marginBottom: 12 }}>
+        <Button onClick={handleMutateData}>修改 data 引用</Button>
+        <Button onClick={handleAddChild} style={{ marginLeft: 8 }}>
+          给 Parent 2 添加子节点
+        </Button>
+        <Button onClick={() => setExpandKeys([1, 2, 22])} style={{ marginLeft: 8 }}>
+          展开全部
+        </Button>
+        <Button onClick={() => setExpandKeys([])} style={{ marginLeft: 8 }}>
+          收起全部
+        </Button>
+      </div>
+      <Table
+        data={data}
+        columns={columns}
+        keygen="id"
+        treeColumnsName="children"
+        treeExpandKeys={expandKeys}
+        onTreeExpand={(openKeys: any) => setExpandKeys(openKeys)}
+      />
+    </div>
+  )
+}
+
+export default App

--- a/site/pages/documentation/changelog/2.x.x.md
+++ b/site/pages/documentation/changelog/2.x.x.md
@@ -1,5 +1,8 @@
 # 更新日志
 
+### 2.0.32
+- 修复 `Table` 使用 `treeExpandKeys` 展开树形行时，若数据中包含 DOM 引用等不可序列化字段会导致页面崩溃的问题
+
 ### 2.0.31
 - 新增 RTL 模式下 `Modal`、`Popover`、`Tooltip` 组件的位置自动镜像转换功能
 - 修复 `Select` OptionList 中 optionInner 未定义导致的报错

--- a/src/Table/TreeExpand.tsx
+++ b/src/Table/TreeExpand.tsx
@@ -2,6 +2,7 @@ import React, { ComponentType } from 'react'
 import immer from 'immer'
 import { getKey } from '../utils/uid'
 import { keysToArray } from '../utils/transform'
+import { safeDeepClone } from '../utils/clone'
 import { KeygenResult } from '../@types/common'
 import { TableProps, GetTreeExpandProps } from './Props'
 
@@ -81,7 +82,7 @@ export default <DataItem, Value>(WrappedComponent: ComponentType<TableProps<Data
 
       const storeExpandKeys = new Map()
       expandKeys.forEach((value, key) => storeExpandKeys.set(key, value))
-      const cloneData = JSON.parse(JSON.stringify(data))
+      const cloneData = safeDeepClone(data)
       return immer(cloneData, (draft: any) => {
         let dataCo = draft
         for (let i = 0; i < dataCo.length; i++) {

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 
 import * as utils from './utils'
 
-export default { utils, version: '2.0.31' }
+export default { utils, version: '2.0.32-beta.1' }
 export { utils }
 export { setLocale } from './locale'
 export { color, style } from './utils/expose'

--- a/src/utils/clone.ts
+++ b/src/utils/clone.ts
@@ -42,3 +42,34 @@ export const deepClone = (source: any) => {
   if (isMergeable(source)) return cloneObject(source)
   return shallowClone(source)
 }
+
+export const safeDeepClone = (source: any, seen?: WeakMap<object, any>): any => {
+  if (source === null || typeof source !== 'object') return source
+  if (isDate(source)) return new Date(source.getTime())
+  if (isRegexp(source)) return new RegExp(source)
+  if ((source as any).$$typeof !== undefined) return source
+  if (typeof Node !== 'undefined' && source instanceof Node) return source
+
+  if (!seen) seen = new WeakMap()
+  if (seen.has(source)) return seen.get(source)
+
+  if (isArray(source)) {
+    const arr: any[] = []
+    seen.set(source, arr)
+    for (let i = 0; i < source.length; i++) {
+      arr[i] = safeDeepClone(source[i], seen)
+    }
+    return arr
+  }
+
+  const proto = Object.getPrototypeOf(source)
+  if (proto !== Object.prototype && proto !== null) return source
+
+  const clone: any = {}
+  seen.set(source, clone)
+  const keys = Object.keys(source)
+  for (let i = 0; i < keys.length; i++) {
+    clone[keys[i]] = safeDeepClone(source[keys[i]], seen)
+  }
+  return clone
+}


### PR DESCRIPTION
## 问题描述

Table 组件使用 `treeExpandKeys` 展开树形行时，若 `data` 中包含 DOM 节点引用、React Ref 等不可 JSON 序列化的字段，`JSON.parse(JSON.stringify(data))` 会因循环引用直接报错导致页面崩溃。

## 修复方案

新增 `safeDeepClone` 工具函数替代 `JSON.stringify` 深拷贝：
- 使用 WeakMap 追踪已访问对象，避免循环引用导致无限递归
- 跳过 React 元素（`$$typeof`）和 DOM 节点，保持原引用
- 仅对纯数组和纯 Object 做递归深拷贝，断开 data 引用
- 保留原有能力：用户直接修改 data 后 Table 仍能响应式更新

## 测试

- Table 组件 114 个测试用例全部通过
- 新增 test-004-tree-expand-mutate 示例验证 DOM 引用场景