### PR TITLE
fix: 修复 Modal 在 onClose 中调用 closeAll 导致栈溢出的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shineout",
-  "version": "2.0.32-beta.4",
+  "version": "2.0.32-beta.5",
   "description": "Shein 前端组件库",
   "main": "./lib/index.js",
   "module": "./es/index.js",

--- a/site/pages/documentation/changelog/2.x.x.md
+++ b/site/pages/documentation/changelog/2.x.x.md
@@ -1,9 +1,8 @@
 # 更新日志
 
-### 2.0.33
-- 修复 `Form` 调用 `validateClear` 传入指定字段名时，若对应字段未注册校验器会导致报错的问题
-
 ### 2.0.32
+- 修复 `Modal` 通过 `Modal.show` 等方法打开的弹窗，在 `onClose` 中调用 `Modal.closeAll` 时会触发无限递归导致栈溢出报错的问题
+- 修复 `Form` 调用 `validateClear` 传入指定字段名时，若对应字段未注册校验器会导致报错的问题
 - 修复 `Table` 使用 `treeExpandKeys` 展开树形行时，若数据中包含 DOM 引用等不可序列化字段会导致页面崩溃的问题
 - 修复 `Grid` 组件动态生成的样式在微前端场景下被错误劫持导致样式失效的问题
 - 修复 `Dropdown` 嵌套使用 `absolute` 时子级菜单项点击无法触发 onClick 的问题（Regression: since 2.0.29）

--- a/src/Modal/events.tsx
+++ b/src/Modal/events.tsx
@@ -224,14 +224,22 @@ export const method = (type: Methods) => (option: Options) => {
   return () => close(props)
 }
 
+let closingAll = false
 export const closeAll = () => {
-  Object.keys(containers)
-    .filter(id => containers[id].props.from === 'method' && containers[id].visible)
-    .forEach(id => {
-      const { onClose, usePortal } = containers[id].props
-      if (onClose) onClose()
-      if (!usePortal) close(containers[id].props)
-    })
+  // 防止用户在 onClose 回调中再次调用 closeAll 造成无限递归
+  if (closingAll) return
+  closingAll = true
+  try {
+    Object.keys(containers)
+      .filter(id => containers[id].props.from === 'method' && containers[id].visible)
+      .forEach(id => {
+        const { onClose, usePortal } = containers[id].props
+        if (onClose) onClose()
+        if (!usePortal) close(containers[id].props)
+      })
+  } finally {
+    closingAll = false
+  }
 }
 
 ready(() => {

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 
 import * as utils from './utils'
 
-export default { utils, version: '2.0.32-beta.4' }
+export default { utils, version: '2.0.32-beta.5' }
 export { utils }
 export { setLocale } from './locale'
 export { color, style } from './utils/expose'


### PR DESCRIPTION
## 问题描述

通过 `Modal.show` / `Modal.confirm` 等方法打开的弹窗，若业务在 `onClose` 回调中调用 `Modal.closeAll()`，点击右上角关闭图标时浏览器会抛出：

```
Uncaught RangeError: Maximum call stack size exceeded
```

弹窗无法关闭，页面卡死，必须刷新才能恢复。该问题在 v1 下不存在，属于 v2 的回归问题。

## 复现路径

`site/pages/components/Modal/example-1-base.tsx`：

```tsx
Modal.show({
  title: '删除测试',
  onClose: () => {
    Modal.closeAll()
  },
})
```

点击 Modal 右上角 X 即触发栈溢出。

## 根因分析

v2 自 #1908 起，`closeAll` 在关闭每个弹窗前会主动调用其 `onClose` 回调（v1 不会）。当用户的 `onClose` 内部又调 `closeAll` 时，链路变为：

```
点 X → handleClose → onClose() → closeAll()
                                    └─ 遍历每个弹窗：
                                       ├─ onClose() → closeAll() → onClose() → ... 无限递归
                                       └─ close() (never reached)
```

由于 `close()` 尚未执行，弹窗的 `visible` 仍为 `true`，每一层 `closeAll` 都能找到同一个弹窗继续递归，最终爆栈。

## 修复方案

在 `closeAll` 执行期间增加重入守卫，嵌套调用直接 return，阻断递归路径。修复对正常的 `closeAll` 调用、ESC 关闭、确认按钮关闭等其它路径无任何影响。

## 影响范围

- `src/Modal/events.tsx`：`closeAll` 增加重入守卫
- `site/pages/documentation/changelog/2.x.x.md`：2.0.32 段新增 changelog 条目