### PR TITLE
fix: Modal closeAll 异步触发 onClose，修复与 V1 行为不一致的 Breaking Change

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shineout",
-  "version": "2.0.32-beta.5",
+  "version": "2.0.32-beta.6",
   "description": "Shein 前端组件库",
   "main": "./lib/index.js",
   "module": "./es/index.js",

--- a/src/Modal/events.tsx
+++ b/src/Modal/events.tsx
@@ -224,22 +224,35 @@ export const method = (type: Methods) => (option: Options) => {
   return () => close(props)
 }
 
-let closingAll = false
+// PR #1908 (commit 76cba77d) 在 closeAll 中新增了同步调用 onClose 的逻辑，
+// 这引发了两个问题：
+//
+// 1. 无限递归 —— 用户在 onClose 中再次调用 closeAll() 会导致栈溢出
+//    (RangeError: Maximum call stack size exceeded)，
+//    后续 commit eb355ef4 通过 closingAll 重入守卫修复了此问题。
+//
+// 2. Breaking Change —— 与 V1 行为不一致。
+//    典型场景：用户在 Modal.show 的 content 中通过 onClick 调用
+//    closeAll() + resolve(true)，同时在 onClose 中调用
+//    closeAll() + resolve(false)。
+//    V1: closeAll 不触发 onClose → resolve(true) 先执行 → 结果为 true。
+//    V2(同步): closeAll 同步触发 onClose → resolve(false) 抢先执行 → 结果为 false。
+//    这对 V1 升级 V2 的用户是一个 Breaking Change。
+//
+// 修复方案：将 onClose 改为 setTimeout 异步触发。
+// - 保留 PR #1908 "closeAll 触发 onClose" 的 feature（通知业务层做清理）。
+// - closeAll 同步完成所有 close() 调用后，调用者的后续代码先执行，
+//   onClose 在下一个事件循环才触发，不会抢占调用者的 resolve。
+// - close() 同步将 visible 置为 false，onClose 异步执行时即使再调
+//   closeAll()，filter 结果为空数组，天然不会递归，无需重入守卫。
 export const closeAll = () => {
-  // 防止用户在 onClose 回调中再次调用 closeAll 造成无限递归
-  if (closingAll) return
-  closingAll = true
-  try {
-    Object.keys(containers)
-      .filter(id => containers[id].props.from === 'method' && containers[id].visible)
-      .forEach(id => {
-        const { onClose, usePortal } = containers[id].props
-        if (onClose) onClose()
-        if (!usePortal) close(containers[id].props)
-      })
-  } finally {
-    closingAll = false
-  }
+  Object.keys(containers)
+    .filter(id => containers[id].props.from === 'method' && containers[id].visible)
+    .forEach(id => {
+      const { onClose, usePortal } = containers[id].props
+      if (onClose) setTimeout(() => onClose(), 0)
+      if (!usePortal) close(containers[id].props)
+    })
 }
 
 ready(() => {

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 
 import * as utils from './utils'
 
-export default { utils, version: '2.0.32-beta.5' }
+export default { utils, version: '2.0.32-beta.6' }
 export { utils }
 export { setLocale } from './locale'
 export { color, style } from './utils/expose'


### PR DESCRIPTION
## 问题背景

PR #1908 (commit 76cba77d) 在 `closeAll` 中新增了**同步调用 `onClose`** 的逻辑，这引发了两个问题：

### 问题 1：无限递归（已由 #2219 修复）

用户在 `onClose` 中再次调用 `closeAll()` 会导致栈溢出（`RangeError: Maximum call stack size exceeded`）。#2219 (commit eb355ef4) 通过 `closingAll` 重入守卫修复了此问题。

### 问题 2：Breaking Change — 与 V1 行为不一致（本 PR 修复）

典型场景：用户在 `Modal.show` 的 content 中通过 `onClick` 调用 `closeAll() + resolve(true)`，同时在 `onClose` 中调用 `closeAll() + resolve(false)`。

| 版本 | closeAll 是否触发 onClose | resolve 执行顺序 | 最终结果 |
|------|--------------------------|-----------------|---------|
| V1   | ❌ 不触发                 | resolve(true) 先执行 | `true` ✅ |
| V2 (同步) | ✅ 同步触发           | resolve(false) 抢先执行 | `false` ❌ |

这对 V1 升级 V2 的用户是一个 **Breaking Change**。

## 修复方案

将 `onClose` 改为 `setTimeout` **异步触发**：

```javascript
// Before (同步)
if (onClose) onClose()

// After (异步)
if (onClose) setTimeout(() => onClose(), 0)
```

### 为什么这个方案能同时解决两个问题

1. **保留 PR #1908 的 feature** — `closeAll` 仍然触发 `onClose`，业务层的清理逻辑不丢失。
2. **消除 Breaking Change** — `closeAll` 同步完成所有 `close()` 调用后，调用者的后续代码（如 `resolve(true)`）先执行，`onClose` 在下一个事件循环才触发，不会抢占调用者的 resolve。
3. **天然防递归，无需重入守卫** — `close()` 同步将 `visible` 置为 `false`，`onClose` 异步执行时即使再调 `closeAll()`，filter 结果为空数组，不会递归。因此移除了 `closingAll` 守卫。

## 关联 PR

- 本 PR 是 #2219 的后续修复。#2219 解决了 PR #1908 引入的无限递归问题，本 PR 进一步解决了同一根因导致的 Breaking Change 问题，并以更优雅的方式（异步触发）替代了重入守卫方案。