### PR TITLE
fix: 修复弹出类组件开启 absolute 后在非 Modal 场景下被自动注入 z-index，导致用户 CSS 层级覆盖失效的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shineout",
-  "version": "2.0.32-beta.6",
+  "version": "2.0.32-beta.7",
   "description": "Shein 前端组件库",
   "main": "./lib/index.js",
   "module": "./es/index.js",

--- a/site/pages/documentation/changelog/2.x.x.md
+++ b/site/pages/documentation/changelog/2.x.x.md
@@ -6,6 +6,7 @@
 - 修复 `Table` 使用 `treeExpandKeys` 展开树形行时，若数据中包含 DOM 引用等不可序列化字段会导致页面崩溃的问题
 - 修复 `Grid` 组件动态生成的样式在微前端场景下被错误劫持导致样式失效的问题
 - 修复 `Dropdown` 嵌套使用 `absolute` 时子级菜单项点击无法触发 onClick 的问题（Regression: since 2.0.29）
+- 修复弹出类组件开启 `absolute` 后在非 `Modal` 场景下被自动注入 `z-index`，导致用户 CSS 层级覆盖失效的问题（Regression: since 2.0.23）
 
 ### 2.0.31
 - 新增 RTL 模式下 `Modal`、`Popover`、`Tooltip` 组件的位置自动镜像转换功能

--- a/src/Modal/Panel.tsx
+++ b/src/Modal/Panel.tsx
@@ -224,7 +224,8 @@ export default class Panel extends PureComponent<ModalPanelProps> {
     const showClose = typeof hideClose === 'boolean' ? !hideClose : maskCloseAble || maskCloseAble === null
     const maskStyle = { paddingBottom: fullScreen ? 0 : top }
     return (
-      <ZProvider value>
+      <ZProvider value={{}}>
+
         <Provider value={{ element: undefined }}>
           <div
             {...events}

--- a/src/Modal/context.tsx
+++ b/src/Modal/context.tsx
@@ -1,7 +1,13 @@
 import React from 'react'
 import createReactContext from '../context'
 
-const context = createReactContext({})
+// 默认值为 null，表示"不在 Modal 内部"。
+// 修复：原来默认值为 {}（truthy），导致所有开启 absolute 的弹出类组件（Dropdown/Select 等）
+// 无论是否在 Modal 内，都会被自动注入 zIndex: 1051（inline style），
+// 使用户通过 CSS 覆盖 z-index 的方式完全失效（Breaking Change since 2.0.23）。
+// 现改为 null，只有在 Modal Provider 内部时（value != null）才注入 zIndex，
+// 与 v1 行为保持一致。
+const context = createReactContext<object | null>(null)
 
 // eslint-disable-next-line
 export const Provider = context.Provider
@@ -11,7 +17,7 @@ const consumer = <Props extends {}>(Origin: React.ComponentType<Props>) => (
 ) => (
   <context.Consumer>
     {value => {
-      const mp = Object.assign({}, props, value && props.absolute && props.zIndex === undefined && { zIndex: 1051 })
+      const mp = Object.assign({}, props, value != null && props.absolute && props.zIndex === undefined && { zIndex: 1051 })
       return <Origin {...mp} />
     }}
   </context.Consumer>

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 
 import * as utils from './utils'
 
-export default { utils, version: '2.0.32-beta.6' }
+export default { utils, version: '2.0.32-beta.7' }
 export { utils }
 export { setLocale } from './locale'
 export { color, style } from './utils/expose'


### PR DESCRIPTION
## 问题描述

弹出类组件（Dropdown、Select、DatePicker 等）开启 `absolute` 属性后，即使不在 `Modal` 内，也会被自动注入 `style="z-index: 1051"`。由于 inline style 优先级最高，用户通过 CSS 自定义 z-index 的方式完全失效，且从 v1 升级到 v2 后行为不一致。

**Regression: since 2.0.23**（commit: 5dd2ee04，PR #1856 Modal Drawer TS 重构时将 Context 默认值从 `undefined` 改为 `{}`，导致 zIndex 注入逻辑在所有场景下触发）

## 修复方案

将 Modal Context 默认值由 `{}`（truthy）改回 `null`，使 zIndex 自动注入行为仅在真正处于 Modal 内部时生效，与 v1 行为保持一致。

同步修复 `Modal/Panel.tsx` 中 `<ZProvider value>` 的 TypeScript 类型错误（`boolean` 不兼容 `object | null`）。

## 变更文件

- `src/Modal/context.tsx` — Context 默认值 `{}` → `null`，条件判断 `value &&` → `value != null &&`
- `src/Modal/Panel.tsx` — `<ZProvider value>` → `<ZProvider value={{}}>`
- `site/pages/documentation/changelog/2.x.x.md` — 补充 changelog