### PR TITLE
fix: 修复 Select 使用键盘方向键循环导航后继续向上，下拉列表内容区域白屏的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shineout",
-  "version": "2.0.32-beta.7",
+  "version": "2.0.32-beta.8",
   "description": "Shein 前端组件库",
   "main": "./lib/index.js",
   "module": "./es/index.js",

--- a/site/pages/documentation/changelog/2.x.x.md
+++ b/site/pages/documentation/changelog/2.x.x.md
@@ -7,6 +7,7 @@
 - 修复 `Grid` 组件动态生成的样式在微前端场景下被错误劫持导致样式失效的问题
 - 修复 `Dropdown` 嵌套使用 `absolute` 时子级菜单项点击无法触发 onClick 的问题（Regression: since 2.0.29）
 - 修复弹出类组件开启 `absolute` 后在非 `Modal` 场景下被自动注入 `z-index`，导致用户 CSS 层级覆盖失效的问题（Regression: since 2.0.23）
+- 修复 `Select` 使用键盘方向键循环导航后继续向上，下拉列表内容区域白屏的问题
 
 ### 2.0.31
 - 新增 RTL 模式下 `Modal`、`Popover`、`Tooltip` 组件的位置自动镜像转换功能

--- a/src/Select/OptionList.tsx
+++ b/src/Select/OptionList.tsx
@@ -98,7 +98,7 @@ class OptionList<Item, Value> extends Component<OptionListProps<Item, Value>, Op
       this.lastScrollTop = emptyHeight - offset
 
       currentIndex = hoverIndex - 1
-      if (currentIndex < 0) currentIndex = max
+      if (currentIndex < 0) currentIndex = 0
       this.setState({ currentIndex, scrollTop: emptyHeight / (lineHeight * max) })
     } else if (emptyHeight + lineHeight > this.lastScrollTop + offset + height) {
       // absolute at bottom

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 
 import * as utils from './utils'
 
-export default { utils, version: '2.0.32-beta.7' }
+export default { utils, version: '2.0.32-beta.8' }
 export { utils }
 export { setLocale } from './locale'
 export { color, style } from './utils/expose'


### PR DESCRIPTION
## 问题描述

修复 `Select` 组件使用键盘方向键循环导航（到达列表顶部后继续向上），下拉列表内容区域出现白屏的问题。

## 问题原因

在 `OptionList.tsx` 中，当用户向上导航且 `currentIndex < 0` 时，代码将 `currentIndex` 重置为 `max`（列表最大索引），导致 `scrollTop` 计算出现异常，从而引发白屏。

## 修复方案

将循环到顶部时的 `currentIndex` 由 `max` 改为 `0`，避免异常的滚动位置计算。

## 变更内容

- `src/Select/OptionList.tsx`: 修复键盘导航边界处理逻辑
- `package.json` / `src/index.js`: 版本号升级至 `2.0.32-beta.8`
- `site/pages/documentation/changelog/2.x.x.md`: 更新 changelog