### PR TITLE
fix: 修复 DatePicker、Select、TreeSelect、Cascader 禁用状态下触发 onBlur/onFocus 的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shineout",
-  "version": "2.0.32-beta.8",
+  "version": "2.0.32-beta.9",
   "description": "Shein 前端组件库",
   "main": "./lib/index.js",
   "module": "./es/index.js",

--- a/site/pages/documentation/changelog/2.x.x.md
+++ b/site/pages/documentation/changelog/2.x.x.md
@@ -1,6 +1,7 @@
 # 更新日志
 
 ### 2.0.32
+- 修复 `DatePicker`、`Select`、`TreeSelect`、`Cascader` 组件在禁用状态下仍会触发 onBlur / onFocus 回调的问题
 - 修复 `Modal` 通过 `Modal.show` 等方法打开的弹窗，在 `onClose` 中调用 `Modal.closeAll` 时会触发无限递归导致栈溢出报错的问题
 - 修复 `Form` 调用 `validateClear` 传入指定字段名时，若对应字段未注册校验器会导致报错的问题
 - 修复 `Table` 使用 `treeExpandKeys` 展开树形行时，若数据中包含 DOM 引用等不可序列化字段会导致页面崩溃的问题

--- a/src/Cascader/Cascader.tsx
+++ b/src/Cascader/Cascader.tsx
@@ -269,6 +269,7 @@ class Cascader<DataItem, Value extends CascaderBaseValue> extends PureComponent<
   }
 
   handleClickAway(e: MouseEvent) {
+    if (this.props.disabled === true) return
     const desc = isDescendent(e.target as HTMLElement, this.selectId)
     if (!desc) {
       if (this.props.inputFocus) this.props.onBlur()
@@ -295,6 +296,7 @@ class Cascader<DataItem, Value extends CascaderBaseValue> extends PureComponent<
   }
 
   handleFocus(e: any) {
+    if (this.props.disabled === true) return
     if (!this.shouldFocus(e.target as HTMLDivElement)) return
     this.props.onFocus(e)
   }
@@ -343,6 +345,8 @@ class Cascader<DataItem, Value extends CascaderBaseValue> extends PureComponent<
   }
 
   handleKeyDown(e: any) {
+    if (this.props.disabled === true) return
+
     if (e.keyCode === 13) {
       e.preventDefault()
       this.handleState(!this.focus)

--- a/src/DatePicker/Container.tsx
+++ b/src/DatePicker/Container.tsx
@@ -274,6 +274,7 @@ class Container extends PureComponent<ContainerProps, ContainerState> {
   }
 
   handleClickAway(e: MouseEvent) {
+    if (this.props.disabled === true) return
     const onPicker = e.target === this.element || this.element.contains(e.target as HTMLElement)
     const onAbsolutePicker = getParent(e.target as HTMLElement, `.${datepickerClass('location')}`)
     if (!onPicker && !onAbsolutePicker) {
@@ -284,12 +285,15 @@ class Container extends PureComponent<ContainerProps, ContainerState> {
   }
 
   handleFocus(e: FocusEvent<HTMLDivElement>) {
+    if (this.props.disabled === true) return
     if (!this.shouldFocus(e.target)) return
     if (this.props.onFocus) this.props.onFocus(e)
     this.bindClickAway()
   }
 
   handleKeyDown(e: KeyboardEvent<HTMLDivElement>) {
+    if (this.props.disabled === true) return
+
     if (e.keyCode === 13) {
       e.preventDefault()
       this.handleToggle(!this.focus)

--- a/src/Select/Select.tsx
+++ b/src/Select/Select.tsx
@@ -255,6 +255,7 @@ class Select<Item, Value> extends PureComponent<BaseSelectProps<Item, Value>, Se
   }
 
   handleClickAway(e: any) {
+    if (this.getDisabledStatus() === true) return
     const desc = this.isDescendent(e.target, this.selectId)
     if (!desc) {
       if (!getParent(e.target, `[data-id=${this.selectId}]`)) {
@@ -362,6 +363,7 @@ class Select<Item, Value> extends PureComponent<BaseSelectProps<Item, Value>, Se
   }
 
   handleFocus(e: React.FocusEvent<HTMLDivElement>) {
+    if (this.getDisabledStatus() === true) return
     if (!this.shouldFocus(e.target)) return
     this.props.onFocus(e)
   }
@@ -439,6 +441,8 @@ class Select<Item, Value> extends PureComponent<BaseSelectProps<Item, Value>, Se
   }
 
   handleKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+    if (this.getDisabledStatus() === true) return
+
     const { onEnterExpand } = this.props
     this.keyLocked = true
     // just for enter to open the list

--- a/src/TreeSelect/TreeSelect.tsx
+++ b/src/TreeSelect/TreeSelect.tsx
@@ -195,6 +195,7 @@ export default class TreeSelect<Item, Value extends TreeSelectValueType> extends
   }
 
   handleClickAway(e: any) {
+    if (this.props.disabled === true) return
     const desc = isDescendent(e.target, this.treeSelectId)
     if (!desc) {
       this.clearClickAway()
@@ -225,12 +226,15 @@ export default class TreeSelect<Item, Value extends TreeSelectValueType> extends
   }
 
   handleFocus(e: React.FocusEvent<HTMLDivElement>) {
+    if (this.props.disabled === true) return
     if (!this.shouldFocus(e.target)) return
     this.props.onFocus(e)
     this.bindClickAway()
   }
 
   handleKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+    if (this.props.disabled === true) return
+
     const { onEnterExpand } = this.props
     if (e.keyCode === 13) {
       e.preventDefault()

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 
 import * as utils from './utils'
 
-export default { utils, version: '2.0.32-beta.8' }
+export default { utils, version: '2.0.32-beta.9' }
 export { utils }
 export { setLocale } from './locale'
 export { color, style } from './utils/expose'


### PR DESCRIPTION
## 问题描述

DatePicker、Select、TreeSelect、Cascader 组件设置 `disabled` 后，点击页面其他区域或使用键盘 Tab 键时，仍会触发 `onBlur` / `onFocus` 回调。

## 修复方案

在各组件的 `handleFocus`、`handleClickAway`、`handleKeyDown` 方法中增加 disabled 状态守卫，disabled 时直接 return，不触发任何焦点相关回调。

## 影响范围

- `src/DatePicker/Container.tsx`
- `src/Select/Select.tsx`
- `src/TreeSelect/TreeSelect.tsx`
- `src/Cascader/Cascader.tsx`