### PR TITLE
docs: README 添加 shineout 3.x 新版本仓库指引

### DIFF
--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -1,5 +1,10 @@
 [English](./README.md) | 简体中文
 
+> [!IMPORTANT]
+> **这是 shineout 的 2.x 版本，目前处于维护模式。**
+> 最新的 **3.x 版本** 已在新仓库中发布：👉 [sheinsight/shineout-next](https://github.com/sheinsight/shineout-next)
+> 建议新项目使用 3.x 版本。
+
 <p align="center">
   <img alt="react-router" src="https://user-images.githubusercontent.com/101764/44770646-44f53000-ab9b-11e8-834e-2b1394cea318.png" width="300">
 </p>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 English | [简体中文](./README-zh_CN.md)
 
+> [!IMPORTANT]
+> **This is the 2.x version of shineout, which is now in maintenance mode.**
+> The latest **3.x version** has been released in a new repository: 👉 [sheinsight/shineout-next](https://github.com/sheinsight/shineout-next)
+> We recommend using 3.x for new projects.
+
 <p align="center">
   <img alt="react-router" src="https://user-images.githubusercontent.com/101764/44770646-44f53000-ab9b-11e8-834e-2b1394cea318.png" width="300">
 </p>


### PR DESCRIPTION
在 README.md 和 README-zh_CN.md 顶部添加醒目提示，告知用户：

- 当前仓库为 shineout 2.x 版本，处于维护模式
- 最新 3.x 版本已在 [sheinsight/shineout-next](https://github.com/sheinsight/shineout-next) 发布
- 建议新项目使用 3.x 版本